### PR TITLE
Added support to get flags and traits in a single API call.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Add following dependencies to your project in `pom.xml`
 <dependency>
   <groupId>com.solidstategroup</groupId>
   <artifactId>bullet-train-client</artifactId>
-  <version>1.5</version>
+  <version>1.6</version>
 </dependency>
 ```
 
 ### Gradle
 ```groovy
-implementation 'com.solidstategroup:bullet-train-client:1.5'
+implementation 'com.solidstategroup:bullet-train-client:1.6'
 ```
 
 ## Usage
@@ -137,6 +137,22 @@ if (userTrait != null) {
 } else {
     // run the code that doesn't depend on the user trait
 }
+```
+
+**Flags and Traits**
+
+Or get flags and traits for a user in a single call:
+
+```Java
+FlagsAndTraits userFlagsAndTraits = bulletClient.getUserFlagsAndTraits(user);
+// get traits
+List<Trait> traits = bulletClient.getTraits(userFlagsAndTraits, "cookies_key");
+// or get a flag value
+String featureFlagValue = bulletClient.getFeatureFlagValue("font_size", userFlagsAndTraits);
+// or get flag enabled
+boolean enabled = bulletClient.hasFeatureFlag("hero", userFlagsAndTraits);
+
+// see above examples on how to evaluate flags and traits
 ```
 
 ## Override default configuration

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.solidstategroup</groupId>
     <artifactId>bullet-train-client</artifactId>
-    <version>1.5</version>
+    <version>1.6</version>
     <packaging>jar</packaging>
 
     <name>Bullet Train Client</name>

--- a/src/test/java/com/solidstategroup/bullettrain/BulletTrainClientTest.java
+++ b/src/test/java/com/solidstategroup/bullettrain/BulletTrainClientTest.java
@@ -6,6 +6,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -104,7 +105,99 @@ public class BulletTrainClientTest {
         List<Trait> userTraits = bulletClient.getTraits(user);
 
         assertNotNull(userTraits, "Should have user traits back");
-        assertTrue(userTraits.size() == 0, "Should have user traits back");
+        assertTrue(userTraits.isEmpty(), "Should have no user traits back");
+    }
+
+    @Test(groups = "integration")
+    public void testClient_When_Get_User_Traits_And_Flags_For_Keys_Then_Success() {
+        // context user
+        FeatureUser user = new FeatureUser();
+        user.setIdentifier("another_user");
+
+        FlagsAndTraits userFlagsAndTraits = bulletClient.getUserFlagsAndTraits(user);
+
+        assertNotNull(userFlagsAndTraits, "Should have user traits and flags back");
+        assertTrue(!userFlagsAndTraits.getFlags().isEmpty(), "Should have user flags back");
+        assertTrue(!userFlagsAndTraits.getTraits().isEmpty(), "Should have user traits back");
+
+        for (Trait trait : userFlagsAndTraits.getTraits()) {
+            assertNotNull(trait.getValue(), "Flag should have value for trait");
+        }
+        for (Flag flag : userFlagsAndTraits.getFlags()) {
+            assertNotNull(flag.getFeature(), "Flag should have feature");
+        }
+    }
+
+    @Test(groups = "integration")
+    public void testClient_When_Get_User_Traits_And_Flags_For_Invalid_User_Then_Return_Empty() {
+        // context user
+        FeatureUser user = new FeatureUser();
+        user.setIdentifier("invalid_users_another_user");
+
+        FlagsAndTraits userFlagsAndTraits = bulletClient.getUserFlagsAndTraits(user);
+
+        assertNotNull(userFlagsAndTraits, "Should have user traits and flags back, not null");
+        assertTrue(!userFlagsAndTraits.getFlags().isEmpty(), "Should have user flags back");
+        assertTrue(userFlagsAndTraits.getTraits().isEmpty(), "Should have no user traits back");
+
+        for (Flag flag : userFlagsAndTraits.getFlags()) {
+            assertNotNull(flag.getFeature(), "Flag should have feature");
+        }
+    }
+
+    @Test(groups = "integration")
+    public void testClient_When_Get_User_Trait_From_Traits_And_Flags_For_Keys_Then_Success() {
+        // context user
+        FeatureUser user = new FeatureUser();
+        user.setIdentifier("another_user");
+
+        FlagsAndTraits userFlagsAndTraits = bulletClient.getUserFlagsAndTraits(user);
+
+        Trait userTrait = bulletClient.getTrait(userFlagsAndTraits, "cookies_key");
+
+        assertNotNull(userTrait, "Should have user traits back");
+        assertNotNull(userTrait.getValue(), "Should have user traits value");
+    }
+
+    @Test(groups = "integration")
+    public void testClient_When_Get_User_Traits_From_Traits_And_Flags_For_Keys_Then_Success() {
+        // context user
+        FeatureUser user = new FeatureUser();
+        user.setIdentifier("another_user");
+
+        FlagsAndTraits userFlagsAndTraits = bulletClient.getUserFlagsAndTraits(user);
+
+        List<Trait> traits = bulletClient.getTraits(userFlagsAndTraits, "cookies_key");
+
+        assertNotNull(traits, "Should have user traits back");
+        assertNotNull(traits.size() == 1, "Should have 1 user trait");
+        assertNotNull(traits.get(0).getValue(), "Should have user trait value");
+    }
+
+    @Test(groups = "integration")
+    public void testClient_When_Get_User_FLag_Value_From_Traits_And_Flags_For_Keys_Then_Success() {
+        // context user
+        FeatureUser user = new FeatureUser();
+        user.setIdentifier("another_user");
+
+        FlagsAndTraits userFlagsAndTraits = bulletClient.getUserFlagsAndTraits(user);
+
+        String featureFlagValue = bulletClient.getFeatureFlagValue("font_size", userFlagsAndTraits);
+
+        assertEquals("12", featureFlagValue, "Should have feature 'font_size' with value '12'");
+    }
+
+    @Test(groups = "integration")
+    public void testClient_When_Get_User_FLag_Enabled_From_Traits_And_Flags_For_Keys_Then_Success() {
+        // context user
+        FeatureUser user = new FeatureUser();
+        user.setIdentifier("another_user");
+
+        FlagsAndTraits userFlagsAndTraits = bulletClient.getUserFlagsAndTraits(user);
+
+        boolean enabled = bulletClient.hasFeatureFlag("hero", userFlagsAndTraits);
+
+        assertTrue(enabled, "Should have feature 'hero' enabled");
     }
 
     @Test(groups = "integration")


### PR DESCRIPTION
Added support to be able to get flags and traits in a single call, and then add logic based on both. Rather than making a call to get flags and a call to get traits. I also added methods that accept this object to get single flags/traits in case this object is being cached.