### PR TITLE
Added logging when an HTTP exception occurs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Add following dependencies to your project in `pom.xml`
 <dependency>
   <groupId>com.flagsmith</groupId>
   <artifactId>flagsmith-java-client</artifactId>
-  <version>2.0</version>
+  <version>2.1</version>
 </dependency>
 ```
 
 ### Gradle
 ```groovy
-implementation 'com.flagsmith:flagsmith-java-client:2.0'
+implementation 'com.flagsmith:flagsmith-java-client:2.1'
 ```
 
 ## Usage
@@ -118,7 +118,7 @@ if (userTrait != null) {
 Or get the user traits for a given user context and specific keys:
 
 ```Java
- List<Trait> userTraits = flagsmithClient.getTraits(user, "cookies_key", "other_trait");
+List<Trait> userTraits = flagsmithClient.getTraits(user, "cookies_key", "other_trait");
 if (userTraits != null) {    
     // run the code that uses the user traits
 } else {
@@ -129,7 +129,7 @@ if (userTraits != null) {
 To update the value for user traits for a given user context and specific keys:
 
 ```Java
- Trait userTrait = flagsmithClient.getTrait(user, "cookies_key");
+Trait userTrait = flagsmithClient.getTrait(user, "cookies_key");
 if (userTrait != null) {    
     // update the value for a user trait
     userTrait.setValue("new value");
@@ -179,6 +179,26 @@ FlagsmithClient flagsmithClient = FlagsmithClient.newBuilder()
                     .build())
             .build();
 
+```
+
+logging is disabled by default. If you would like to enable it then call `.enableLogging()` on the client builder:
+
+```java
+FlagsmithClient flagsmithClient = FlagsmithClient.newBuilder()
+                // other configuration as shown above
+                .enableLogging()
+                .build();
+```
+
+Flagsmith uses [SLF4J](http://www.slf4j.org) and we only implement its API.
+If your project does not already have SLF4J, then include an implementation, i.e.:
+
+```xml
+<dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-simple</artifactId>
+    <version>${slf4j.version}</version>
+</dependency>
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -201,6 +201,19 @@ If your project does not already have SLF4J, then include an implementation, i.e
 </dependency>
 ```
 
+adding custom headers to all HTTP calls:
+
+```java
+final HashMap<String, String> customHeaders = new HashMap(){{
+    put("x-custom-header", "value1");
+    put("x-my-key", "value2");
+}};
+FlagsmithClient flagsmithClient = FlagsmithClient.newBuilder()
+    // other configuration as shown above
+    .withCustomHttpHeaders(customHeaders)
+    .build();
+```
+
 ## Contributing
 
 Please read [CONTRIBUTING.md](https://gist.github.com/kyle-ssg/c36a03aebe492e45cbd3eefb21cb0486) for details on our Code of Conduct, and the process for submitting Pull Requests to us.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.flagsmith</groupId>
     <artifactId>flagsmith-java-client</artifactId>
-    <version>2.0</version>
+    <version>2.1</version>
     <packaging>jar</packaging>
 
     <name>Flagsmith Java Client</name>
@@ -41,7 +41,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <jacksonVersion>2.10.1</jacksonVersion>
-        <lombok.version>1.16.20</lombok.version>
+        <lombok.version>1.18.16</lombok.version>
+        <slf4j.version>1.7.30</slf4j.version>
     </properties>
 
 
@@ -75,6 +76,18 @@
             <version>${lombok.version}</version>
             <scope>compile</scope>
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/flagsmith/FlagsmithClient.java
+++ b/src/main/java/com/flagsmith/FlagsmithClient.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -26,6 +27,7 @@ public class FlagsmithClient {
     // an api key per environment
     private String apiKey;
     private Logger logger;
+    private HashMap<String, String> customHeaders;
 
     private FlagsmithClient() {
     }
@@ -55,9 +57,7 @@ public class FlagsmithClient {
                     .addEncodedPathSegment(user.getIdentifier());
         }
 
-        Request request = new Request.Builder()
-                .header(AUTH_HEADER, apiKey)
-                .addHeader(ACCEPT_HEADER, "application/json")
+        final Request request = this.newRequestBuilder()
                 .url(urlBuilder.build())
                 .build();
 
@@ -296,9 +296,7 @@ public class FlagsmithClient {
                 .addEncodedQueryParameter("identifier", user.getIdentifier())
                 .build();
 
-        Request request = new Request.Builder()
-                .header(AUTH_HEADER, apiKey)
-                .addHeader(ACCEPT_HEADER, "application/json")
+        final Request request = this.newRequestBuilder()
                 .url(url)
                 .build();
 
@@ -358,9 +356,7 @@ public class FlagsmithClient {
         MediaType JSON = MediaType.parse("application/json; charset=utf-8");
         RequestBody body = RequestBody.create(JSON, identityTraits.toString());
 
-        Request request = new Request.Builder()
-                .header(AUTH_HEADER, apiKey)
-                .addHeader(ACCEPT_HEADER, "application/json")
+        final Request request = this.newRequestBuilder()
                 .post(body)
                 .url(url)
                 .build();
@@ -389,9 +385,7 @@ public class FlagsmithClient {
         MediaType JSON = MediaType.parse("application/json; charset=utf-8");
         RequestBody body = RequestBody.create(JSON, toUpdate.toString());
 
-        Request request = new Request.Builder()
-                .header(AUTH_HEADER, apiKey)
-                .addHeader(ACCEPT_HEADER, "application/json")
+        Request request = this.newRequestBuilder()
                 .post(body)
                 .url(url)
                 .build();
@@ -415,6 +409,18 @@ public class FlagsmithClient {
 
     public static FlagsmithClient.Builder newBuilder() {
         return new FlagsmithClient.Builder();
+    }
+
+    private Request.Builder newRequestBuilder() {
+        final Request.Builder builder = new Request.Builder()
+            .header(AUTH_HEADER, apiKey)
+            .addHeader(ACCEPT_HEADER, "application/json");
+
+        if (this.customHeaders != null && !this.customHeaders.isEmpty()) {
+            this.customHeaders.forEach((k, v) -> builder.addHeader(k, v));
+        }
+
+        return builder;
     }
 
 
@@ -478,6 +484,17 @@ public class FlagsmithClient {
                         .baseURI(apiUrl)
                         .build();
             }
+            return this;
+        }
+
+        /**
+         * Add custom HTTP headers to the calls.
+         *
+         * @param customHeaders headers.
+         * @return the Builder
+         */
+        public Builder withCustomHttpHeaders(HashMap<String, String> customHeaders) {
+            this.client.customHeaders = customHeaders;
             return this;
         }
 

--- a/src/test/java/com/flagsmith/FlagsmithClientHttpErrorsTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithClientHttpErrorsTest.java
@@ -1,55 +1,40 @@
 package com.flagsmith;
 
 import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-/**
- * Unit tests are env specific and will probably will need to adjust keys, identities and
- * features ids etc as required.
- */
-public class FlagsmithClientTest {
+public class FlagsmithClientHttpErrorsTest {
 
-    private static final String API_KEY = "QjgYur4LQTwe5HpvbvhpzK";
+    private static final String API_KEY = "bad-key";
     FlagsmithClient bulletClient;
 
     @BeforeTest
     public void init() {
         bulletClient = FlagsmithClient.newBuilder()
                 .setApiKey(API_KEY)
+                .withApiUrl("http://bad-url")
+                .enableLogging()
                 .build();
     }
 
     @Test(groups = "integration")
-    public void testClient_When_Get_Features_Then_Success() {
+    public void testClient_When_Get_Features_Then_Empty() {
         List<Flag> featureFlags = bulletClient.getFeatureFlags();
 
         assertNotNull(featureFlags, "Should feature flags back");
-        assertTrue(featureFlags.size() > 0, "Should have test featureFlags back");
-
-        for (Flag flag : featureFlags) {
-            assertNotNull(flag.getFeature(), "Flag should have feature");
-        }
-    }
-
-    @Ignore(value = "requires specific features enabled and exist per env")
-    @Test(groups = "integration")
-    public void testClient_When_Has_Feature_Then_Success() {
-        // This will return false
-        boolean featureEnabled = bulletClient.hasFeatureFlag("flag_feature");
-
-        assertTrue(featureEnabled, "Should have test featureFlags back");
+        assertTrue(featureFlags.isEmpty(), "Should not have test featureFlags back");
     }
 
     @Test(groups = "integration")
-    public void testClient_When_Get_Features_For_User_Then_Success() {
+    public void testClient_When_Get_Features_For_User_Then_Empty() {
         // context user
         FeatureUser user = new FeatureUser();
         user.setIdentifier("bullet_train_sample_user");
@@ -57,60 +42,45 @@ public class FlagsmithClientTest {
         List<Flag> featureFlags = bulletClient.getFeatureFlags(user);
 
         assertNotNull(featureFlags, "Should have feature flags back");
-        assertTrue(featureFlags.size() > 0, "Should have test featureFlags back");
-
-        for (Flag flag : featureFlags) {
-            assertNotNull(flag.getFeature(), "Flag should have feature");
-        }
+        assertTrue(featureFlags.isEmpty(), "Should not have test featureFlags back");
     }
 
 
     @Test(groups = "integration")
-    public void testClient_When_Get_User_Traits_Then_Success() {
+    public void testClient_When_Get_User_Traits_Then_Null() {
         // context user
         FeatureUser user = new FeatureUser();
         user.setIdentifier("another_user");
 
         List<Trait> userTraits = bulletClient.getTraits(user);
 
-        assertNotNull(userTraits, "Should have user traits back");
-        assertTrue(userTraits.size() > 0, "Should have test featureFlags back");
-
-        for (Trait trait : userTraits) {
-            assertNotNull(trait.getValue(), "Flag should have value for trait");
-        }
+        assertNull(userTraits, "Should have user traits back");
     }
 
     @Test(groups = "integration")
-    public void testClient_When_Get_User_Traits_For_Keys_Then_Success() {
+    public void testClient_When_Get_User_Traits_For_Keys_Then_Null() {
         // context user
         FeatureUser user = new FeatureUser();
         user.setIdentifier("another_user");
 
         List<Trait> userTraits = bulletClient.getTraits(user, "cookies_key");
 
-        assertNotNull(userTraits, "Should have user traits back");
-        assertTrue(userTraits.size() == 1, "Should have test featureFlags back");
-
-        for (Trait trait : userTraits) {
-            assertNotNull(trait.getValue(), "Flag should have value for trait");
-        }
+        assertNull(userTraits, "Should have user traits back");
     }
 
     @Test(groups = "integration")
-    public void testClient_When_Get_User_Traits_For_Invalid_User_Then_Return_Empty() {
+    public void testClient_When_Get_User_Traits_For_Invalid_User_Then_Return_Null() {
         // context user
         FeatureUser user = new FeatureUser();
         user.setIdentifier("invalid_users_another_user");
 
         List<Trait> userTraits = bulletClient.getTraits(user);
 
-        assertNotNull(userTraits, "Should have user traits back");
-        assertTrue(userTraits.isEmpty(), "Should have no user traits back");
+        assertNull(userTraits, "Should have user traits back");
     }
 
     @Test(groups = "integration")
-    public void testClient_When_Get_User_Traits_And_Flags_For_Keys_Then_Success() {
+    public void testClient_When_Get_User_Traits_And_Flags_For_Keys_Then_Null_Lists() {
         // context user
         FeatureUser user = new FeatureUser();
         user.setIdentifier("another_user");
@@ -118,19 +88,12 @@ public class FlagsmithClientTest {
         FlagsAndTraits userFlagsAndTraits = bulletClient.getUserFlagsAndTraits(user);
 
         assertNotNull(userFlagsAndTraits, "Should have user traits and flags back");
-        assertTrue(!userFlagsAndTraits.getFlags().isEmpty(), "Should have user flags back");
-        assertTrue(!userFlagsAndTraits.getTraits().isEmpty(), "Should have user traits back");
-
-        for (Trait trait : userFlagsAndTraits.getTraits()) {
-            assertNotNull(trait.getValue(), "Flag should have value for trait");
-        }
-        for (Flag flag : userFlagsAndTraits.getFlags()) {
-            assertNotNull(flag.getFeature(), "Flag should have feature");
-        }
+        assertNull(userFlagsAndTraits.getFlags(), "Should not have user flags back");
+        assertNull(userFlagsAndTraits.getTraits(), "Should not have user traits back");
     }
 
     @Test(groups = "integration")
-    public void testClient_When_Get_User_Traits_And_Flags_For_Invalid_User_Then_Return_Empty() {
+    public void testClient_When_Get_User_Traits_And_Flags_For_Invalid_User_Then_Return_Null_Lists() {
         // context user
         FeatureUser user = new FeatureUser();
         user.setIdentifier("invalid_users_another_user");
@@ -138,16 +101,12 @@ public class FlagsmithClientTest {
         FlagsAndTraits userFlagsAndTraits = bulletClient.getUserFlagsAndTraits(user);
 
         assertNotNull(userFlagsAndTraits, "Should have user traits and flags back, not null");
-        assertTrue(!userFlagsAndTraits.getFlags().isEmpty(), "Should have user flags back");
-        assertTrue(userFlagsAndTraits.getTraits().isEmpty(), "Should have no user traits back");
-
-        for (Flag flag : userFlagsAndTraits.getFlags()) {
-            assertNotNull(flag.getFeature(), "Flag should have feature");
-        }
+        assertNull(userFlagsAndTraits.getFlags(), "Should not have user flags back");
+        assertNull(userFlagsAndTraits.getTraits(), "Should not have no user traits back");
     }
 
     @Test(groups = "integration")
-    public void testClient_When_Get_User_Trait_From_Traits_And_Flags_For_Keys_Then_Success() {
+    public void testClient_When_Get_User_Trait_From_Traits_And_Flags_For_Keys_Then_Null() {
         // context user
         FeatureUser user = new FeatureUser();
         user.setIdentifier("another_user");
@@ -156,12 +115,11 @@ public class FlagsmithClientTest {
 
         Trait userTrait = bulletClient.getTrait(userFlagsAndTraits, "cookies_key");
 
-        assertNotNull(userTrait, "Should have user traits back");
-        assertNotNull(userTrait.getValue(), "Should have user traits value");
+        assertNull(userTrait, "Should not have user traits back");
     }
 
     @Test(groups = "integration")
-    public void testClient_When_Get_User_Traits_From_Traits_And_Flags_For_Keys_Then_Success() {
+    public void testClient_When_Get_User_Traits_From_Traits_And_Flags_For_Keys_Then_Null() {
         // context user
         FeatureUser user = new FeatureUser();
         user.setIdentifier("another_user");
@@ -170,13 +128,11 @@ public class FlagsmithClientTest {
 
         List<Trait> traits = bulletClient.getTraits(userFlagsAndTraits, "cookies_key");
 
-        assertNotNull(traits, "Should have user traits back");
-        assertNotNull(traits.size() == 1, "Should have 1 user trait");
-        assertNotNull(traits.get(0).getValue(), "Should have user trait value");
+        assertNull(traits, "Should not have user traits back");
     }
 
     @Test(groups = "integration")
-    public void testClient_When_Get_User_FLag_Value_From_Traits_And_Flags_For_Keys_Then_Success() {
+    public void testClient_When_Get_User_FLag_Value_From_Traits_And_Flags_For_Keys_Then_Null() {
         // context user
         FeatureUser user = new FeatureUser();
         user.setIdentifier("another_user");
@@ -185,11 +141,11 @@ public class FlagsmithClientTest {
 
         String featureFlagValue = bulletClient.getFeatureFlagValue("font_size", userFlagsAndTraits);
 
-        assertEquals("12", featureFlagValue, "Should have feature 'font_size' with value '12'");
+        assertNull(featureFlagValue, "Should not have feature");
     }
 
     @Test(groups = "integration")
-    public void testClient_When_Get_User_FLag_Enabled_From_Traits_And_Flags_For_Keys_Then_Success() {
+    public void testClient_When_Get_User_FLag_Enabled_From_Traits_And_Flags_For_Keys_Then_False() {
         // context user
         FeatureUser user = new FeatureUser();
         user.setIdentifier("another_user");
@@ -198,34 +154,31 @@ public class FlagsmithClientTest {
 
         boolean enabled = bulletClient.hasFeatureFlag("hero", userFlagsAndTraits);
 
-        assertTrue(enabled, "Should have feature 'hero' enabled");
+        assertFalse(enabled, "Should not have feature enabled");
     }
 
     @Test(groups = "integration")
-    public void testClient_When_Get_User_Trait_Then_Success() {
+    public void testClient_When_Get_User_Trait_Then_Null() {
         FeatureUser user = new FeatureUser();
         user.setIdentifier("another_user");
 
         Trait userTrait = bulletClient.getTrait(user, "cookies_key");
 
-        assertNotNull(userTrait, "Should have user traits back");
-        assertNotNull(userTrait.getValue(), "Should have user traits value");
+        assertNull(userTrait, "Should not have user traits back");
     }
 
 
     @Test(groups = "integration")
-    public void testClient_When_Get_User_Trait_Update_Then_Updated() {
+    public void testClient_When_Get_User_Trait_Update_Then_Null() {
         FeatureUser user = new FeatureUser();
         user.setIdentifier("another_user");
 
-        Trait userTrait = bulletClient.getTrait(user, "cookies_key");
-        assertNotNull(userTrait, "Should have user traits back");
-        assertNotNull(userTrait.getValue(), "Should have user traits value");
-
+        Trait userTrait = new Trait();
+        userTrait.setIdentity(user);
+        userTrait.setKey("some_trait");
         userTrait.setValue("new value");
         Trait updated = bulletClient.updateTrait(user, userTrait);
-        assertNotNull(updated, "Should have updated user traits back");
-        assertTrue(updated.getValue().equals("new value"));
+        assertNull(updated, "Should not have updated user traits back");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, groups = "integration")
@@ -261,13 +214,7 @@ public class FlagsmithClientTest {
         List<Trait> traits = bulletClient.identifyUserWithTraits(user,  Arrays.asList(trait1, trait2));
 
         // Then
-        assertEquals(2, traits.size(), "Should have 2 traits returned");
-
-        assertTrue(trait1.getKey().equals(traits.get(0).getKey()));
-        assertTrue(trait1.getValue().equals(traits.get(0).getValue()));
-
-        assertTrue(trait2.getKey().equals(traits.get(1).getKey()));
-        assertTrue(trait2.getValue().equals(traits.get(1).getValue()));
+        assertTrue(traits.isEmpty(), "Should not have traits returned");
     }
 
 }

--- a/src/test/java/com/flagsmith/FlagsmithClientHttpErrorsTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithClientHttpErrorsTest.java
@@ -4,6 +4,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.testng.Assert.assertFalse;
@@ -14,6 +15,10 @@ import static org.testng.Assert.assertTrue;
 public class FlagsmithClientHttpErrorsTest {
 
     private static final String API_KEY = "bad-key";
+    private static final HashMap<String, String> customHeaders = new HashMap(){{
+        put("x-custom-header", "value1");
+        put("x-my-key", "value2");
+    }};
     FlagsmithClient bulletClient;
 
     @BeforeTest
@@ -21,6 +26,7 @@ public class FlagsmithClientHttpErrorsTest {
         bulletClient = FlagsmithClient.newBuilder()
                 .setApiKey(API_KEY)
                 .withApiUrl("http://bad-url")
+                .withCustomHttpHeaders(customHeaders)
                 .enableLogging()
                 .build();
     }


### PR DESCRIPTION
Hi guys,

We would like to have error logs when an HTTP error occurs and we need to be able to send custom headers (to be able to get through our own API gateway). Other than that the behaviour remains the same. Included in this PR:

Commit 1:

- Added a SLF4J logger, that logs errors in the catch blocks from HTTP calls.
- Logging is disabled by default. To enable it, a developer has to configure it as part of the builder.
- Added unit tests for failed HTTP calls.

Commit 2:

- Added custom HTTP headers.

Tested with Spring Boot 2.3.3.RELEASE.

For now the logging is done very simplistic, but I reckon it could later be extended to include more information logs, and a configurable log level as part of the builder.

There are 2 git commits, one for each "feature".

Cheers,
Olga 