### PR TITLE
Refactor code to have endpoints centralised

### DIFF
--- a/src/main/java/com/flagsmith/FlagsmithClient.java
+++ b/src/main/java/com/flagsmith/FlagsmithClient.java
@@ -20,13 +20,8 @@ import java.util.List;
  */
 public class FlagsmithClient {
 
-    private FlagsmithConfig defaultConfig;
-    private static final String AUTH_HEADER = "X-Environment-Key";
-    private static final String ACCEPT_HEADER = "Accept";
-    // an api key per environment
-    private String apiKey;
     private final FlagsmithLogger logger = new FlagsmithLogger();
-    private HashMap<String, String> customHeaders;
+    private FlagsmithEndpoints flagsmithEndpoints;
 
     private FlagsmithClient() {
     }
@@ -58,34 +53,7 @@ public class FlagsmithClient {
      * @return a list of feature flags
      */
     public List<Flag> getFeatureFlags(FeatureUser user, boolean doThrow) {
-        HttpUrl.Builder urlBuilder;
-        if (user == null) {
-            urlBuilder = defaultConfig.flagsURI.newBuilder()
-                    .addEncodedQueryParameter("page", "1");
-        } else {
-            urlBuilder = defaultConfig.flagsURI.newBuilder("")
-                    .addEncodedPathSegment(user.getIdentifier());
-        }
-
-        final Request request = this.newRequestBuilder()
-                .url(urlBuilder.build())
-                .build();
-
-        Call call = defaultConfig.httpClient.newCall(request);
-        List<Flag> featureFlags = new ArrayList<>();
-        try (Response response = call.execute()) {
-            if (response.isSuccessful()) {
-                ObjectMapper mapper = MapperFactory.getMappper();
-                featureFlags = Arrays.asList(mapper.readValue(response.body().string(),
-                        Flag[].class));
-            } else {
-                logger.httpError(request, response, doThrow);
-            }
-        } catch (IOException io) {
-            logger.httpError(request, io, doThrow);
-        }
-        logger.info("Got feature flags for user = {}, flags = {}", user, featureFlags);
-        return featureFlags;
+        return this.flagsmithEndpoints.getFeatureFlags(user, doThrow);
     }
 
     /**
@@ -315,29 +283,7 @@ public class FlagsmithClient {
      * @return a list of user Traits and Flags
      */
     public FlagsAndTraits getUserFlagsAndTraits(FeatureUser user, boolean doThrow) {
-        HttpUrl url = defaultConfig.identitiesURI.newBuilder("")
-                .addEncodedQueryParameter("identifier", user.getIdentifier())
-                .build();
-
-        final Request request = this.newRequestBuilder()
-                .url(url)
-                .build();
-
-        Call call = defaultConfig.httpClient.newCall(request);
-
-        FlagsAndTraits flagsAndTraits = new FlagsAndTraits();
-        try (Response response = call.execute()) {
-            if (response.isSuccessful()) {
-                ObjectMapper mapper = MapperFactory.getMappper();
-                flagsAndTraits = mapper.readValue(response.body().string(), FlagsAndTraits.class);
-            } else {
-                logger.httpError(request, response, doThrow);
-            }
-        } catch (IOException io) {
-            logger.httpError(request, io, doThrow);
-        }
-        logger.info("Got feature flags & traits for user = {}, flagsAndTraits = {}", user, flagsAndTraits);
-        return flagsAndTraits;
+        return this.flagsmithEndpoints.getUserFlagsAndTraits(user, doThrow);
     }
 
     /**
@@ -360,7 +306,7 @@ public class FlagsmithClient {
      * @return a Trait object or null if does not exist
      */
     public Trait updateTrait(FeatureUser user, Trait toUpdate, boolean doThrow) {
-        return postUserTraits(user, toUpdate, doThrow);
+        return this.flagsmithEndpoints.postUserTraits(user, toUpdate, doThrow);
     }
 
     /**
@@ -393,94 +339,18 @@ public class FlagsmithClient {
      * @return a list of added Trait objects
      */
     public List<Trait> identifyUserWithTraits(FeatureUser user, List<Trait> traits, boolean doThrow) {
-        // we are using identities endpoint to create bulk user Trait
-        HttpUrl url = defaultConfig.identitiesURI;
-
-        if (user == null || (user.getIdentifier() == null || user.getIdentifier().length() < 1)) {
-            throw new IllegalArgumentException("Missing user Identifier");
-        }
-
-        IdentityTraits identityTraits = new IdentityTraits();
-        identityTraits.setIdentifier(user.getIdentifier());
-        if (traits != null) {
-            identityTraits.setTraits(traits);
-        }
-
-        MediaType JSON = MediaType.parse("application/json; charset=utf-8");
-        RequestBody body = RequestBody.create(JSON, identityTraits.toString());
-
-        final Request request = this.newRequestBuilder()
-                .post(body)
-                .url(url)
-                .build();
-
-        List<Trait> traitsData = new ArrayList<>();
-        Call call = defaultConfig.httpClient.newCall(request);
-        try (Response response = call.execute()) {
-            if (response.isSuccessful()) {
-                ObjectMapper mapper = MapperFactory.getMappper();
-                FlagsAndTraits flagsAndTraits = mapper.readValue(response.body().string(), FlagsAndTraits.class);
-
-                traitsData = flagsAndTraits.getTraits();
-            } else {
-                logger.httpError(request, response, doThrow);
-            }
-        } catch (IOException io) {
-            logger.httpError(request, io, doThrow);
-        }
-        logger.info("Got traits for user = {}, traits = {}", user, traitsData);
-        return traitsData;
+        return flagsmithEndpoints.identifyUserWithTraits(user, traits, doThrow);
     }
-
-    private Trait postUserTraits(FeatureUser user, Trait toUpdate, boolean doThrow) {
-        HttpUrl url = defaultConfig.traitsURI;
-        toUpdate.setIdentity(user);
-
-        MediaType JSON = MediaType.parse("application/json; charset=utf-8");
-        RequestBody body = RequestBody.create(JSON, toUpdate.toString());
-
-        Request request = this.newRequestBuilder()
-                .post(body)
-                .url(url)
-                .build();
-
-        Trait trait = null;
-        Call call = defaultConfig.httpClient.newCall(request);
-        try (Response response = call.execute()) {
-            if (response.isSuccessful()) {
-                ObjectMapper mapper = MapperFactory.getMappper();
-                trait = mapper.readValue(response.body().string(), Trait.class);
-            } else {
-                logger.httpError(request, response, doThrow);
-            }
-        } catch (IOException io) {
-            logger.httpError(request, io, doThrow);
-        }
-        logger.info("Updated trait for user = {}, new trait = {}, updated trait = {}", user, toUpdate, trait);
-        return trait;
-    }
-
 
     public static FlagsmithClient.Builder newBuilder() {
         return new FlagsmithClient.Builder();
     }
 
-    private Request.Builder newRequestBuilder() {
-        final Request.Builder builder = new Request.Builder()
-            .header(AUTH_HEADER, apiKey)
-            .addHeader(ACCEPT_HEADER, "application/json");
-
-        if (this.customHeaders != null && !this.customHeaders.isEmpty()) {
-            this.customHeaders.forEach((k, v) -> builder.addHeader(k, v));
-        }
-
-        return builder;
-    }
-
-
     public static class Builder {
         private FlagsmithClient client;
         private FlagsmithConfig configuration = FlagsmithConfig.newBuilder().build();
+        private HashMap<String, String> customHeaders;
+        private String apiKey;
 
         private Builder() {
             client = new FlagsmithClient();
@@ -496,7 +366,7 @@ public class FlagsmithClient {
             if (null == apiKey) {
                 throw new IllegalArgumentException("Api key can not be null");
             } else {
-                client.apiKey = apiKey;
+                this.apiKey = apiKey;
                 return this;
             }
         }
@@ -557,13 +427,13 @@ public class FlagsmithClient {
          * @return the Builder
          */
         public Builder withCustomHttpHeaders(HashMap<String, String> customHeaders) {
-            this.client.customHeaders = customHeaders;
+            this.customHeaders = customHeaders;
             return this;
         }
 
         public FlagsmithClient build() {
-            client.defaultConfig = this.configuration;
-            return client;
+            this.client.flagsmithEndpoints = new FlagsmithEndpoints(this.configuration, this.customHeaders, client.logger, apiKey);
+            return this.client;
         }
     }
 }

--- a/src/main/java/com/flagsmith/FlagsmithEndpoints.java
+++ b/src/main/java/com/flagsmith/FlagsmithEndpoints.java
@@ -1,0 +1,173 @@
+package com.flagsmith;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.Call;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+public class FlagsmithEndpoints {
+
+  private final FlagsmithConfig defaultConfig;
+  private final FlagsmithLogger logger;
+  private final HashMap<String, String> customHeaders;
+  private static final String AUTH_HEADER = "X-Environment-Key";
+  private static final String ACCEPT_HEADER = "Accept";
+  // an api key per environment
+  private final String apiKey;
+
+  public FlagsmithEndpoints(final FlagsmithConfig defaultConfig,
+                            final HashMap<String, String> customHeaders,
+                            final FlagsmithLogger logger,
+                            final String apiKey) {
+    this.defaultConfig = defaultConfig;
+    this.customHeaders = customHeaders;
+    this.logger = logger;
+    this.apiKey = apiKey;
+  }
+
+  public List<Flag> getFeatureFlags(FeatureUser user, boolean doThrow) {
+    HttpUrl.Builder urlBuilder;
+    if (user == null) {
+      urlBuilder = defaultConfig.flagsURI.newBuilder()
+          .addEncodedQueryParameter("page", "1");
+    } else {
+      urlBuilder = defaultConfig.flagsURI.newBuilder("")
+          .addEncodedPathSegment(user.getIdentifier());
+    }
+
+    final Request request = this.newRequestBuilder()
+        .url(urlBuilder.build())
+        .build();
+
+    Call call = defaultConfig.httpClient.newCall(request);
+    List<Flag> featureFlags = new ArrayList<>();
+    try (Response response = call.execute()) {
+      if (response.isSuccessful()) {
+        ObjectMapper mapper = MapperFactory.getMappper();
+        featureFlags = Arrays.asList(mapper.readValue(response.body().string(),
+            Flag[].class));
+      } else {
+        logger.httpError(request, response, doThrow);
+      }
+    } catch (IOException io) {
+      logger.httpError(request, io, doThrow);
+    }
+    logger.info("Got feature flags for user = {}, flags = {}", user, featureFlags);
+    return featureFlags;
+  }
+
+  public FlagsAndTraits getUserFlagsAndTraits(FeatureUser user, boolean doThrow) {
+    HttpUrl url = defaultConfig.identitiesURI.newBuilder("")
+        .addEncodedQueryParameter("identifier", user.getIdentifier())
+        .build();
+
+    final Request request = this.newRequestBuilder()
+        .url(url)
+        .build();
+
+    Call call = defaultConfig.httpClient.newCall(request);
+
+    FlagsAndTraits flagsAndTraits = new FlagsAndTraits();
+    try (Response response = call.execute()) {
+      if (response.isSuccessful()) {
+        ObjectMapper mapper = MapperFactory.getMappper();
+        flagsAndTraits = mapper.readValue(response.body().string(), FlagsAndTraits.class);
+      } else {
+        logger.httpError(request, response, doThrow);
+      }
+    } catch (IOException io) {
+      logger.httpError(request, io, doThrow);
+    }
+    logger.info("Got feature flags & traits for user = {}, flagsAndTraits = {}", user, flagsAndTraits);
+    return flagsAndTraits;
+  }
+
+  public List<Trait> identifyUserWithTraits(FeatureUser user, List<Trait> traits, boolean doThrow) {
+    // we are using identities endpoint to create bulk user Trait
+    HttpUrl url = defaultConfig.identitiesURI;
+
+    if (user == null || (user.getIdentifier() == null || user.getIdentifier().length() < 1)) {
+      throw new IllegalArgumentException("Missing user Identifier");
+    }
+
+    IdentityTraits identityTraits = new IdentityTraits();
+    identityTraits.setIdentifier(user.getIdentifier());
+    if (traits != null) {
+      identityTraits.setTraits(traits);
+    }
+
+    MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+    RequestBody body = RequestBody.create(JSON, identityTraits.toString());
+
+    final Request request = this.newRequestBuilder()
+        .post(body)
+        .url(url)
+        .build();
+
+    List<Trait> traitsData = new ArrayList<>();
+    Call call = defaultConfig.httpClient.newCall(request);
+    try (Response response = call.execute()) {
+      if (response.isSuccessful()) {
+        ObjectMapper mapper = MapperFactory.getMappper();
+        FlagsAndTraits flagsAndTraits = mapper.readValue(response.body().string(), FlagsAndTraits.class);
+
+        traitsData = flagsAndTraits.getTraits();
+      } else {
+        logger.httpError(request, response, doThrow);
+      }
+    } catch (IOException io) {
+      logger.httpError(request, io, doThrow);
+    }
+    logger.info("Got traits for user = {}, traits = {}", user, traitsData);
+    return traitsData;
+  }
+
+  public Trait postUserTraits(FeatureUser user, Trait toUpdate, boolean doThrow) {
+    HttpUrl url = defaultConfig.traitsURI;
+    toUpdate.setIdentity(user);
+
+    MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+    RequestBody body = RequestBody.create(JSON, toUpdate.toString());
+
+    Request request = this.newRequestBuilder()
+        .post(body)
+        .url(url)
+        .build();
+
+    Trait trait = null;
+    Call call = defaultConfig.httpClient.newCall(request);
+    try (Response response = call.execute()) {
+      if (response.isSuccessful()) {
+        ObjectMapper mapper = MapperFactory.getMappper();
+        trait = mapper.readValue(response.body().string(), Trait.class);
+      } else {
+        logger.httpError(request, response, doThrow);
+      }
+    } catch (IOException io) {
+      logger.httpError(request, io, doThrow);
+    }
+    logger.info("Updated trait for user = {}, new trait = {}, updated trait = {}", user, toUpdate, trait);
+    return trait;
+  }
+
+  private Request.Builder newRequestBuilder() {
+    final Request.Builder builder = new Request.Builder()
+        .header(AUTH_HEADER, apiKey)
+        .addHeader(ACCEPT_HEADER, "application/json");
+
+    if (this.customHeaders != null && !this.customHeaders.isEmpty()) {
+      this.customHeaders.forEach((k, v) -> builder.addHeader(k, v));
+    }
+
+    return builder;
+  }
+}

--- a/src/test/java/com/flagsmith/FlagTest.java
+++ b/src/test/java/com/flagsmith/FlagTest.java
@@ -29,9 +29,8 @@ public class FlagTest {
             "    \"identity\": null\n" +
             "  }";
 
-    @Test(groups = "integration")
+    @Test(groups = "unit")
     public void test_When_Parsed_Then_Success() throws IOException {
-
         Flag flag = new Flag();
         flag.parse(json);
 

--- a/src/test/java/com/flagsmith/FlagsmithClientHttpErrorsTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithClientHttpErrorsTest.java
@@ -32,7 +32,7 @@ public class FlagsmithClientHttpErrorsTest {
                 .build();
     }
 
-    @Test(groups = "integration")
+    @Test(groups = "integration-down")
     public void testClient_When_Get_Features_Then_Empty() {
         List<Flag> featureFlags = flagsmithClient.getFeatureFlags();
 
@@ -40,7 +40,7 @@ public class FlagsmithClientHttpErrorsTest {
         assertTrue(featureFlags.isEmpty(), "Should not have test featureFlags back");
     }
 
-    @Test(groups = "integration")
+    @Test(groups = "integration-down")
     public void testClient_When_Get_Features_For_User_Then_Empty() {
         // context user
         FeatureUser user = new FeatureUser();
@@ -52,7 +52,7 @@ public class FlagsmithClientHttpErrorsTest {
         assertTrue(featureFlags.isEmpty(), "Should not have test featureFlags back");
     }
 
-    @Test(groups = "integration", expectedExceptions = FlagsmithException.class)
+    @Test(groups = "integration-down", expectedExceptions = FlagsmithException.class)
     public void testClient_When_Get_Features_For_User_Then_Throw() {
         // context user
         FeatureUser user = new FeatureUser();
@@ -61,7 +61,7 @@ public class FlagsmithClientHttpErrorsTest {
         flagsmithClient.getFeatureFlags(user, true);
     }
 
-    @Test(groups = "integration")
+    @Test(groups = "integration-down")
     public void testClient_When_Get_User_Traits_Then_Null() {
         // context user
         FeatureUser user = new FeatureUser();
@@ -72,7 +72,7 @@ public class FlagsmithClientHttpErrorsTest {
         assertNull(userTraits, "Should have user traits back");
     }
 
-    @Test(groups = "integration")
+    @Test(groups = "integration-down")
     public void testClient_When_Get_User_Traits_For_Keys_Then_Null() {
         // context user
         FeatureUser user = new FeatureUser();
@@ -83,7 +83,7 @@ public class FlagsmithClientHttpErrorsTest {
         assertNull(userTraits, "Should have user traits back");
     }
 
-    @Test(groups = "integration")
+    @Test(groups = "integration-down")
     public void testClient_When_Get_User_Traits_For_Invalid_User_Then_Return_Null() {
         // context user
         FeatureUser user = new FeatureUser();
@@ -94,7 +94,7 @@ public class FlagsmithClientHttpErrorsTest {
         assertNull(userTraits, "Should have user traits back");
     }
 
-    @Test(groups = "integration")
+    @Test(groups = "integration-down")
     public void testClient_When_Get_User_Traits_And_Flags_For_Keys_Then_Null_Lists() {
         // context user
         FeatureUser user = new FeatureUser();
@@ -107,7 +107,7 @@ public class FlagsmithClientHttpErrorsTest {
         assertNull(userFlagsAndTraits.getTraits(), "Should not have user traits back");
     }
 
-    @Test(groups = "integration")
+    @Test(groups = "integration-down")
     public void testClient_When_Get_User_Traits_And_Flags_For_Invalid_User_Then_Return_Null_Lists() {
         // context user
         FeatureUser user = new FeatureUser();
@@ -120,7 +120,7 @@ public class FlagsmithClientHttpErrorsTest {
         assertNull(userFlagsAndTraits.getTraits(), "Should not have no user traits back");
     }
 
-    @Test(groups = "integration", expectedExceptions = FlagsmithException.class)
+    @Test(groups = "integration-down", expectedExceptions = FlagsmithException.class)
     public void testClient_When_Get_User_Traits_And_Flags_Then_Throw() {
         // context user
         FeatureUser user = new FeatureUser();
@@ -129,7 +129,7 @@ public class FlagsmithClientHttpErrorsTest {
         flagsmithClient.getUserFlagsAndTraits(user, true);
     }
 
-    @Test(groups = "integration", expectedExceptions = FlagsmithException.class)
+    @Test(groups = "integration-down", expectedExceptions = FlagsmithException.class)
     public void testClient_When_Get_User_Traits_And_Flags_Then_Throw_evenIfLoggingDisabled() {
         // context user
         FeatureUser user = new FeatureUser();
@@ -144,7 +144,7 @@ public class FlagsmithClientHttpErrorsTest {
         flagsmithClient.getUserFlagsAndTraits(user, true);
     }
 
-    @Test(groups = "integration")
+    @Test(groups = "integration-down")
     public void testClient_When_Get_User_Trait_From_Traits_And_Flags_For_Keys_Then_Null() {
         // context user
         FeatureUser user = new FeatureUser();
@@ -157,7 +157,7 @@ public class FlagsmithClientHttpErrorsTest {
         assertNull(userTrait, "Should not have user traits back");
     }
 
-    @Test(groups = "integration")
+    @Test(groups = "integration-down")
     public void testClient_When_Get_User_Traits_From_Traits_And_Flags_For_Keys_Then_Null() {
         // context user
         FeatureUser user = new FeatureUser();
@@ -170,7 +170,7 @@ public class FlagsmithClientHttpErrorsTest {
         assertNull(traits, "Should not have user traits back");
     }
 
-    @Test(groups = "integration")
+    @Test(groups = "integration-down")
     public void testClient_When_Get_User_FLag_Value_From_Traits_And_Flags_For_Keys_Then_Null() {
         // context user
         FeatureUser user = new FeatureUser();
@@ -183,7 +183,7 @@ public class FlagsmithClientHttpErrorsTest {
         assertNull(featureFlagValue, "Should not have feature");
     }
 
-    @Test(groups = "integration")
+    @Test(groups = "integration-down")
     public void testClient_When_Get_User_FLag_Enabled_From_Traits_And_Flags_For_Keys_Then_False() {
         // context user
         FeatureUser user = new FeatureUser();
@@ -196,7 +196,7 @@ public class FlagsmithClientHttpErrorsTest {
         assertFalse(enabled, "Should not have feature enabled");
     }
 
-    @Test(groups = "integration")
+    @Test(groups = "integration-down")
     public void testClient_When_Get_User_Trait_Then_Null() {
         FeatureUser user = new FeatureUser();
         user.setIdentifier("another_user");
@@ -207,7 +207,7 @@ public class FlagsmithClientHttpErrorsTest {
     }
 
 
-    @Test(groups = "integration")
+    @Test(groups = "integration-down")
     public void testClient_When_Get_User_Trait_Update_Then_Null() {
         FeatureUser user = new FeatureUser();
         user.setIdentifier("another_user");
@@ -221,7 +221,7 @@ public class FlagsmithClientHttpErrorsTest {
     }
 
 
-    @Test(groups = "integration", expectedExceptions = FlagsmithException.class)
+    @Test(groups = "integration-down", expectedExceptions = FlagsmithException.class)
     public void testClient_When_Get_User_Trait_Update_Then_Throw() {
         FeatureUser user = new FeatureUser();
         user.setIdentifier("another_user");
@@ -233,7 +233,7 @@ public class FlagsmithClientHttpErrorsTest {
         flagsmithClient.updateTrait(user, userTrait, true);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class, groups = "integration")
+    @Test(expectedExceptions = IllegalArgumentException.class, groups = "integration-down")
     public void testClient_When_Add_Traits_For_Identity_With_Missing_Identity_Then_Failed() {
         // Given traits and no user Identity
         Trait trait1 = new Trait();
@@ -248,7 +248,7 @@ public class FlagsmithClientHttpErrorsTest {
         assertTrue(traits.size() == 0, "Should not return any traits");
     }
 
-    @Test(groups = "integration")
+    @Test(groups = "integration-down")
     public void testClient_When_Add_Traits_For_Identity_Then_Success() {
         // Given
         FeatureUser user = new FeatureUser();
@@ -269,7 +269,7 @@ public class FlagsmithClientHttpErrorsTest {
         assertTrue(traits.isEmpty(), "Should not have traits returned");
     }
 
-    @Test(groups = "integration", expectedExceptions = FlagsmithException.class)
+    @Test(groups = "integration-down", expectedExceptions = FlagsmithException.class)
     public void testClient_When_Add_Traits_For_Identity_Then_Throw() {
         // Given
         FeatureUser user = new FeatureUser();

--- a/src/test/java/com/flagsmith/FlagsmithClientTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithClientTest.java
@@ -1,27 +1,21 @@
 package com.flagsmith;
 
-import com.google.common.collect.ImmutableMap;
-import io.restassured.RestAssured;
-import io.restassured.http.Header;
-import io.restassured.http.Headers;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Network;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.utility.DockerImageName;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
+import static com.flagsmith.FlagsmithTestHelper.assignTraitToUserIdentity;
+import static com.flagsmith.FlagsmithTestHelper.config;
+import static com.flagsmith.FlagsmithTestHelper.createFeature;
+import static com.flagsmith.FlagsmithTestHelper.createProjectEnvironment;
+import static com.flagsmith.FlagsmithTestHelper.createUserIdentity;
+import static com.flagsmith.FlagsmithTestHelper.featureUser;
+import static com.flagsmith.FlagsmithTestHelper.flag;
+import static com.flagsmith.FlagsmithTestHelper.switchFlag;
+import static com.flagsmith.FlagsmithTestHelper.switchFlagForUser;
+import static com.flagsmith.FlagsmithTestHelper.trait;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -31,83 +25,29 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 @Test(groups = "integration")
 public class FlagsmithClientTest {
-    private static final Logger log = LoggerFactory.getLogger(FlagsmithClientTest.class);
-
-    private static final Network network = Network.newNetwork();
-    protected static final int BACKEND_PORT = 8000;
-
-    private static PostgreSQLContainer<?> postgres;
-
-    private static GenericContainer<?> backend;
-
-    private static String token;
-
-    private static int organisationId;
-
-    @BeforeClass
-    public static void beforeClass() {
-        postgres = new PostgreSQLContainer<>(DockerImageName.parse("postgres:10.6-alpine"))
-                .withNetwork(network)
-                .withNetworkAliases("flagsmith-db")
-                .withDatabaseName("flagsmith")
-                .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("flagsmith-db")));
-        postgres.start();
-
-        backend = new GenericContainer<>(DockerImageName.parse("flagsmith/flagsmith-api:v2-5-2"))
-                .withNetwork(network)
-                .withNetworkAliases("flagsmith-be")
-                .withEnv("DJANGO_ALLOWED_HOSTS", "*")
-                .withEnv("DATABASE_URL", String.format("postgresql://%s:%s@%s:%d/%s",
-                        postgres.getUsername(),
-                        postgres.getPassword(),
-                        "flagsmith-db",
-                        PostgreSQLContainer.POSTGRESQL_PORT,
-                        postgres.getDatabaseName()))
-                .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("flagsmith-be")))
-                .withExposedPorts(BACKEND_PORT)
-                .waitingFor(new HttpWaitStrategy().forPath("/health").withHeader("Accept", "application/json"));
-        backend.start();
-
-        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
-        RestAssured.port = backend.getMappedPort(BACKEND_PORT);
-
-        assertThat(RestAssured.get("/api/v1/users/init/").asString())
-                .describedAs("Super user have to be created")
-                .isEqualTo("ADMIN USER CREATED");
-
-        token = flagSmithAuthenticate();
-        organisationId = createOrganisation("Test Organisation");
-    }
-
-    @AfterClass
-    public static void afterClass() {
-        backend.stop();
-        postgres.stop();
-        network.close();
-    }
 
     @Test(groups = "integration")
     public void testClient_When_Get_Features_Then_Success() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Get_Features_Then_Success",
                 "TEST");
 
-        createFeature(new FlagFeature(
+        createFeature(new FlagsmithTestHelper.FlagFeature(
                 "Flag 1",
                 "Description for Flag 1",
                 environment.projectId,
                 true));
-        createFeature(new FlagFeature(
+        createFeature(new FlagsmithTestHelper.FlagFeature(
                 "Flag 2",
                 "Description for Flag 2",
                 environment.projectId,
                 false));
-        createFeature(new ConfigFeature(
+        createFeature(new FlagsmithTestHelper.ConfigFeature(
                 "Config 1",
                 "Description for Config 1",
                 environment.projectId,
                 "xxx"));
-        createFeature(new ConfigFeature(
+        createFeature(new FlagsmithTestHelper.ConfigFeature(
                 "Config 2",
                 "Description for Config 2",
                 environment.projectId,
@@ -128,11 +68,11 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Has_Feature_Then_Success() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Has_Feature_Then_Success",
                 "TEST");
 
-        final int featureId = createFeature(new FlagFeature(
+        final int featureId = createFeature(new FlagsmithTestHelper.FlagFeature(
                 "Flag disabled",
                 null,
                 environment.projectId,
@@ -148,16 +88,16 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Get_Features_For_User_Then_Success() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Get_Features_For_User_Then_Success",
                 "TEST");
 
-        final int featureId = createFeature(new FlagFeature(
+        final int featureId = createFeature(new FlagsmithTestHelper.FlagFeature(
                 "Flag to be enabled for the user",
                 null,
                 environment.projectId,
                 false));
-        createFeature(new FlagFeature(
+        createFeature(new FlagsmithTestHelper.FlagFeature(
                 "Other Flag",
                 null,
                 environment.projectId,
@@ -197,7 +137,7 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Get_User_Traits_Then_Success() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Get_User_Traits_Then_Success",
                 "TEST");
 
@@ -221,7 +161,7 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Get_User_Traits_For_Keys_Then_Success() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Get_User_Traits_For_Keys_Then_Success",
                 "TEST");
 
@@ -245,7 +185,7 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Get_User_Traits_For_Invalid_User_Then_Return_Empty() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Get_User_Traits_For_Invalid_User_Then_Return_Empty",
                 "TEST");
 
@@ -260,16 +200,16 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Get_User_Traits_And_Flags_For_Keys_Then_Success() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Get_User_Traits_And_Flags_For_Keys_Then_Success",
                 "TEST");
 
-        final int featureId = createFeature(new FlagFeature(
+        final int featureId = createFeature(new FlagsmithTestHelper.FlagFeature(
                 "Flag to be enabled for the user",
                 null,
                 environment.projectId,
                 false));
-        createFeature(new FlagFeature(
+        createFeature(new FlagsmithTestHelper.FlagFeature(
                 "Other Flag",
                 null,
                 environment.projectId,
@@ -301,11 +241,11 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Get_User_Traits_And_Flags_For_Invalid_User_Then_Return_Empty() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Get_User_Traits_And_Flags_For_Invalid_User_Then_Return_Empty",
                 "TEST");
 
-        createFeature(new FlagFeature(
+        createFeature(new FlagsmithTestHelper.FlagFeature(
                 "The Flag",
                 null,
                 environment.projectId,
@@ -327,11 +267,11 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Get_User_Trait_From_Traits_And_Flags_For_Keys_Then_Success() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Get_User_Trait_From_Traits_And_Flags_For_Keys_Then_Success",
                 "TEST");
 
-        createFeature(new FlagFeature(
+        createFeature(new FlagsmithTestHelper.FlagFeature(
                 "The Flag",
                 null,
                 environment.projectId,
@@ -352,11 +292,11 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Get_User_Traits_From_Traits_And_Flags_For_Keys_Then_Success() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Get_User_Traits_From_Traits_And_Flags_For_Keys_Then_Success",
                 "TEST");
 
-        createFeature(new FlagFeature(
+        createFeature(new FlagsmithTestHelper.FlagFeature(
                 "The Flag",
                 null,
                 environment.projectId,
@@ -383,16 +323,16 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Get_User_FLag_Value_From_Traits_And_Flags_For_Keys_Then_Success() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Get_User_FLag_Value_From_Traits_And_Flags_For_Keys_Then_Success",
                 "TEST");
 
-        createFeature(new FlagFeature(
+        createFeature(new FlagsmithTestHelper.FlagFeature(
                 "The Flag",
                 null,
                 environment.projectId,
                 false));
-        createFeature(new ConfigFeature(
+        createFeature(new FlagsmithTestHelper.ConfigFeature(
                 "font_size",
                 null,
                 environment.projectId,
@@ -410,11 +350,11 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Get_User_FLag_Enabled_From_Traits_And_Flags_For_Keys_Then_Success() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Get_User_FLag_Enabled_From_Traits_And_Flags_For_Keys_Then_Success",
                 "TEST");
 
-        final int featureId = createFeature(new FlagFeature(
+        final int featureId = createFeature(new FlagsmithTestHelper.FlagFeature(
                 "The Flag",
                 null,
                 environment.projectId,
@@ -434,7 +374,7 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Get_User_Trait_Then_Success() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Get_User_Trait_Then_Success",
                 "TEST");
 
@@ -448,7 +388,7 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Get_User_Trait_Update_Then_Updated() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Get_User_Trait_Update_Then_Updated",
                 "TEST");
 
@@ -470,7 +410,7 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Add_Traits_For_Identity_With_Missing_Identity_Then_Failed() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Add_Traits_For_Identity_With_Missing_Identity_Then_Failed",
                 "TEST");
 
@@ -483,7 +423,7 @@ public class FlagsmithClientTest {
 
     @Test(groups = "integration")
     public void testClient_When_Add_Traits_For_Identity_Then_Success() {
-        final ProjectEnvironment environment = createProjectEnvironment(
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
                 "testClient_When_Add_Traits_For_Identity_Then_Success",
                 "TEST");
 
@@ -499,316 +439,5 @@ public class FlagsmithClientTest {
                         trait(null, "trait_1", "some value1"),
                         trait(null, "trait_2", "some value2")
                 );
-    }
-
-    private ProjectEnvironment createProjectEnvironment(String projectName, String environmentName) {
-        final int projectId = createProject(projectName, organisationId);
-
-        final Map<String, Object> environment = createEnvironment(environmentName, projectId);
-        final String environmentApiKey = (String) environment.get("api_key");
-
-        final FlagsmithClient client = FlagsmithClient.newBuilder()
-                .withApiUrl(String.format("http://localhost:%d/api/v1/", backend.getMappedPort(BACKEND_PORT)))
-                .setApiKey(environmentApiKey)
-                .build();
-        return new ProjectEnvironment(environmentApiKey, projectId, client);
-    }
-
-    private int createFeature(Feature feature) {
-        final ImmutableMap.Builder<Object, Object> builder = ImmutableMap.builder()
-                .put("name", feature.name)
-                .put("type", feature.type)
-                .put("project", feature.projectId);
-        if (feature.description != null) {
-            builder.put("description", feature.description);
-        }
-
-        if (feature instanceof FlagFeature) {
-            builder.put("default_enabled", ((FlagFeature) feature).enabled);
-        } else if (feature instanceof ConfigFeature) {
-            builder.put("initial_value", ((ConfigFeature) feature).value);
-        } else {
-            throw new IllegalStateException("Unsupported feature " + feature);
-        }
-
-        return RestAssured.given()
-                .body(builder.build())
-                .headers(defaultHeaders())
-                .post("/api/v1/projects/{projectPk}/features/", feature.projectId)
-                .then()
-                .statusCode(201)
-                .extract()
-                .jsonPath()
-                .getInt("id");
-    }
-
-    private int createUserIdentity(String userIdentity, String environmentApiKey) {
-        return RestAssured.given()
-                .body(ImmutableMap.of(
-                        "identifier", userIdentity,
-                        "environment", environmentApiKey
-                ))
-                .headers(defaultHeaders())
-                .post("/api/v1/environments/{apiKey}/identities/", environmentApiKey)
-                .then()
-                .statusCode(201)
-                .extract()
-                .jsonPath()
-                .getInt("id");
-    }
-
-    private Map<String, Object> createEnvironment(String name, int projectId) {
-        return RestAssured.given()
-                .body(ImmutableMap.of(
-                        "name", name,
-                        "project", projectId
-                ))
-                .headers(defaultHeaders())
-                .post("/api/v1/environments/")
-                .then()
-                .statusCode(201)
-                .extract()
-                .jsonPath()
-                .getJsonObject("$");
-    }
-
-    private void switchFlag(int featureId, boolean enabled, String apiKey) {
-        final List<Map<String, Object>> features = RestAssured.given()
-                .headers(defaultHeaders())
-                .get("/api/v1/environments/{apiKey}/featurestates/?feature={featureId}",
-                        apiKey, featureId)
-                .then()
-                .statusCode(200)
-                .extract()
-                .jsonPath()
-                .getList("results");
-        if (features.isEmpty()) {
-            RestAssured.given()
-                    .body(ImmutableMap.of(
-                            "enabled", enabled,
-                            "feature", featureId
-                    ))
-                    .headers(defaultHeaders())
-                    .post("/api/v1/environments/{apiKey}/featurestates/", apiKey)
-                    .then()
-                    .statusCode(201);
-        } else {
-            final List<Integer> featureStateIds = features.stream()
-                    .map(jsonMap -> jsonMap.get("id"))
-                    .filter(Integer.class::isInstance)
-                    .map(Integer.class::cast)
-                    .collect(Collectors.toList());
-            if (featureStateIds.size() == 1) {
-                final int featureStateId = featureStateIds.get(0);
-                RestAssured.given()
-                        .body(ImmutableMap.of(
-                                "enabled", enabled,
-                                "feature", featureId
-                        ))
-                        .headers(defaultHeaders())
-                        .put("/api/v1/environments/{apiKey}/featurestates/{featureStateId}/",
-                                apiKey, featureStateId)
-                        .then()
-                        .statusCode(200);
-            } else {
-                throw new IllegalStateException("Unable to decide which feature-state to update: " + features);
-            }
-        }
-    }
-
-    private void switchFlagForUser(int featureId, int userIdentityId, boolean enabled, String apiKey) {
-        final List<Map<String, Object>> features = RestAssured.given()
-                .headers(defaultHeaders())
-                .get("/api/v1/environments/{apiKey}/identities/{identityId}/featurestates/?feature={featureId}",
-                        apiKey, userIdentityId, featureId)
-                .then()
-                .statusCode(200)
-                .extract()
-                .jsonPath()
-                .getList("results");
-        if (features.isEmpty()) {
-            RestAssured.given()
-                    .body(ImmutableMap.of(
-                            "enabled", enabled,
-                            "feature", featureId
-                    ))
-                    .headers(defaultHeaders())
-                    .post("/api/v1/environments/{apiKey}/identities/{identityId}/featurestates/", apiKey, userIdentityId)
-                    .then()
-                    .statusCode(201);
-        } else {
-            final List<Integer> featureStateIds = features.stream()
-                    .filter(jsonMap -> {
-                        final Map<String, Object> identityMap = (Map<String, Object>) jsonMap.get("identity");
-                        return Integer.valueOf(userIdentityId).equals(identityMap.get("id"));
-                    })
-                    .map(jsonMap -> jsonMap.get("id"))
-                    .filter(Integer.class::isInstance)
-                    .map(Integer.class::cast)
-                    .collect(Collectors.toList());
-            if (featureStateIds.size() == 1) {
-                final int featureStateId = featureStateIds.get(0);
-                RestAssured.given()
-                        .body(ImmutableMap.of(
-                                "enabled", enabled,
-                                "feature", featureId
-                        ))
-                        .headers(defaultHeaders())
-                        .put("/api/v1/environments/{apiKey}/identities/{identityId}/featurestates/{featureStateId}/",
-                                apiKey, userIdentityId, featureStateId)
-                        .then()
-                        .statusCode(200);
-            } else {
-                throw new IllegalStateException("Unable to decide which feature-state to update: " + features);
-            }
-        }
-    }
-
-    private void assignTraitToUserIdentity(String userIdentifier, String traitKey, Object traitValue, String apiKey) {
-        RestAssured.given()
-                .body(ImmutableMap.of(
-                        "identity", ImmutableMap.of("identifier", userIdentifier),
-                        "trait_key", traitKey,
-                        "trait_value", traitValue
-                ))
-                .headers(defaultHeaders())
-                .header("x-environment-key", apiKey)
-                .post("/api/v1/traits/")
-                .then()
-                .statusCode(200);
-    }
-
-    private int createProject(String name, int organisationId) {
-        return RestAssured.given()
-                .body(ImmutableMap.of(
-                        "name", name,
-                        "organisation", organisationId
-                ))
-                .headers(defaultHeaders())
-                .post("/api/v1/projects/")
-                .then()
-                .statusCode(201)
-                .extract()
-                .jsonPath()
-                .getInt("id");
-    }
-
-    private static int createOrganisation(String name) {
-        return RestAssured.given()
-                .body(ImmutableMap.of("name", name))
-                .headers(defaultHeaders())
-                .post("/api/v1/organisations/")
-                .then()
-                .statusCode(201)
-                .extract()
-                .jsonPath()
-                .getInt("id");
-    }
-
-    private static String flagSmithAuthenticate() {
-        return RestAssured.given()
-                .body(ImmutableMap.of(
-                        // from https://github.com/Flagsmith/flagsmith-api/blob/v2.5.0/src/app/settings/common.py#L255-L258
-                        "email", "admin@example.com",
-                        "password", "password"
-                ))
-                .header("Content-type", "application/json")
-                .post("/api/v1/auth/login/")
-                .then()
-                .statusCode(200)
-                .extract()
-                .jsonPath()
-                .getString("key");
-    }
-
-    private static Headers defaultHeaders() {
-        return new Headers(
-                new Header("Content-type", "application/json"),
-                new Header("Authorization", "Token " + token));
-    }
-
-    private Flag flag(String name, String description, boolean enabled) {
-        final com.flagsmith.Feature feature = new com.flagsmith.Feature();
-        feature.setName(name);
-        feature.setDescription(description);
-        feature.setType("FLAG");
-
-        final Flag result = new Flag();
-        result.setFeature(feature);
-        result.setEnabled(enabled);
-        return result;
-    }
-
-    private Flag config(String name, String description, String value) {
-        final com.flagsmith.Feature feature = new com.flagsmith.Feature();
-        feature.setName(name);
-        feature.setDescription(description);
-        feature.setType("CONFIG");
-
-        final Flag result = new Flag();
-        result.setFeature(feature);
-        result.setStateValue(value);
-        return result;
-    }
-
-    private Trait trait(String userIdentifier, String key, String value) {
-        final Trait result = new Trait();
-        if (userIdentifier != null) {
-            final FeatureUser user = featureUser(userIdentifier);
-            result.setIdentity(user);
-        }
-        result.setKey(key);
-        result.setValue(value);
-        return result;
-    }
-
-    private FeatureUser featureUser(String identifier) {
-        final FeatureUser user = new FeatureUser();
-        user.setIdentifier(identifier);
-        return user;
-    }
-
-    private static abstract class Feature {
-        final String type;
-        final String name;
-        final String description;
-        final int projectId;
-
-        protected Feature(String type, String name, String description, int projectId) {
-            this.type = type;
-            this.name = name;
-            this.description = description;
-            this.projectId = projectId;
-        }
-    }
-
-    private static class FlagFeature extends Feature {
-        final boolean enabled;
-
-        protected FlagFeature(String name, String description, int projectId, boolean enabled) {
-            super("FLAG", name, description, projectId);
-            this.enabled = enabled;
-        }
-    }
-
-    private static class ConfigFeature extends Feature {
-        final String value;
-
-        protected ConfigFeature(String name, String description, int projectId, String value) {
-            super("CONFIG", name, description, projectId);
-            this.value = value;
-        }
-    }
-
-    private static class ProjectEnvironment {
-        final String apiKey;
-        final int projectId;
-        final FlagsmithClient client;
-
-        private ProjectEnvironment(String apiKey, int projectId, FlagsmithClient client) {
-            this.apiKey = apiKey;
-            this.projectId = projectId;
-            this.client = client;
-        }
     }
 }

--- a/src/test/java/com/flagsmith/FlagsmithTestHelper.java
+++ b/src/test/java/com/flagsmith/FlagsmithTestHelper.java
@@ -1,0 +1,298 @@
+package com.flagsmith;
+
+import com.google.common.collect.ImmutableMap;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.flagsmith.IntegrationSuiteTest.BACKEND_PORT;
+
+public class FlagsmithTestHelper {
+
+  public static ProjectEnvironment createProjectEnvironment(String projectName, String environmentName) {
+    final int projectId = createProject(projectName, IntegrationSuiteTest.TestData.organisationId);
+
+    final Map<String, Object> environment = createEnvironment(environmentName, projectId);
+    final String environmentApiKey = (String) environment.get("api_key");
+
+    final FlagsmithClient client = FlagsmithClient.newBuilder()
+        .withApiUrl(String.format("http://localhost:%d/api/v1/", IntegrationSuiteTest.TestData.backend.getMappedPort(BACKEND_PORT)))
+        .setApiKey(environmentApiKey)
+        .build();
+    return new ProjectEnvironment(environmentApiKey, projectId, client);
+  }
+
+  public static int createFeature(Feature feature) {
+    final ImmutableMap.Builder<Object, Object> builder = ImmutableMap.builder()
+        .put("name", feature.name)
+        .put("type", feature.type)
+        .put("project", feature.projectId);
+    if (feature.description != null) {
+      builder.put("description", feature.description);
+    }
+
+    if (feature instanceof FlagFeature) {
+      builder.put("default_enabled", ((FlagFeature) feature).enabled);
+    } else if (feature instanceof ConfigFeature) {
+      builder.put("initial_value", ((ConfigFeature) feature).value);
+    } else {
+      throw new IllegalStateException("Unsupported feature " + feature);
+    }
+
+    return RestAssured.given()
+        .body(builder.build())
+        .headers(defaultHeaders())
+        .post("/api/v1/projects/{projectPk}/features/", feature.projectId)
+        .then()
+        .statusCode(201)
+        .extract()
+        .jsonPath()
+        .getInt("id");
+  }
+
+  public static int createUserIdentity(String userIdentity, String environmentApiKey) {
+    return RestAssured.given()
+        .body(ImmutableMap.of(
+            "identifier", userIdentity,
+            "environment", environmentApiKey
+        ))
+        .headers(defaultHeaders())
+        .post("/api/v1/environments/{apiKey}/identities/", environmentApiKey)
+        .then()
+        .statusCode(201)
+        .extract()
+        .jsonPath()
+        .getInt("id");
+  }
+
+  public static Map<String, Object> createEnvironment(String name, int projectId) {
+    return RestAssured.given()
+        .body(ImmutableMap.of(
+            "name", name,
+            "project", projectId
+        ))
+        .headers(defaultHeaders())
+        .post("/api/v1/environments/")
+        .then()
+        .statusCode(201)
+        .extract()
+        .jsonPath()
+        .getJsonObject("$");
+  }
+
+  public static void switchFlag(int featureId, boolean enabled, String apiKey) {
+    final List<Map<String, Object>> features = RestAssured.given()
+        .headers(defaultHeaders())
+        .get("/api/v1/environments/{apiKey}/featurestates/?feature={featureId}",
+            apiKey, featureId)
+        .then()
+        .statusCode(200)
+        .extract()
+        .jsonPath()
+        .getList("results");
+    if (features.isEmpty()) {
+      RestAssured.given()
+          .body(ImmutableMap.of(
+              "enabled", enabled,
+              "feature", featureId
+          ))
+          .headers(defaultHeaders())
+          .post("/api/v1/environments/{apiKey}/featurestates/", apiKey)
+          .then()
+          .statusCode(201);
+    } else {
+      final List<Integer> featureStateIds = features.stream()
+          .map(jsonMap -> jsonMap.get("id"))
+          .filter(Integer.class::isInstance)
+          .map(Integer.class::cast)
+          .collect(Collectors.toList());
+      if (featureStateIds.size() == 1) {
+        final int featureStateId = featureStateIds.get(0);
+        RestAssured.given()
+            .body(ImmutableMap.of(
+                "enabled", enabled,
+                "feature", featureId
+            ))
+            .headers(defaultHeaders())
+            .put("/api/v1/environments/{apiKey}/featurestates/{featureStateId}/",
+                apiKey, featureStateId)
+            .then()
+            .statusCode(200);
+      } else {
+        throw new IllegalStateException("Unable to decide which feature-state to update: " + features);
+      }
+    }
+  }
+
+  public static void switchFlagForUser(int featureId, int userIdentityId, boolean enabled, String apiKey) {
+    final List<Map<String, Object>> features = RestAssured.given()
+        .headers(defaultHeaders())
+        .get("/api/v1/environments/{apiKey}/identities/{identityId}/featurestates/?feature={featureId}",
+            apiKey, userIdentityId, featureId)
+        .then()
+        .statusCode(200)
+        .extract()
+        .jsonPath()
+        .getList("results");
+    if (features.isEmpty()) {
+      RestAssured.given()
+          .body(ImmutableMap.of(
+              "enabled", enabled,
+              "feature", featureId
+          ))
+          .headers(defaultHeaders())
+          .post("/api/v1/environments/{apiKey}/identities/{identityId}/featurestates/", apiKey, userIdentityId)
+          .then()
+          .statusCode(201);
+    } else {
+      final List<Integer> featureStateIds = features.stream()
+          .filter(jsonMap -> {
+            final Map<String, Object> identityMap = (Map<String, Object>) jsonMap.get("identity");
+            return Integer.valueOf(userIdentityId).equals(identityMap.get("id"));
+          })
+          .map(jsonMap -> jsonMap.get("id"))
+          .filter(Integer.class::isInstance)
+          .map(Integer.class::cast)
+          .collect(Collectors.toList());
+      if (featureStateIds.size() == 1) {
+        final int featureStateId = featureStateIds.get(0);
+        RestAssured.given()
+            .body(ImmutableMap.of(
+                "enabled", enabled,
+                "feature", featureId
+            ))
+            .headers(defaultHeaders())
+            .put("/api/v1/environments/{apiKey}/identities/{identityId}/featurestates/{featureStateId}/",
+                apiKey, userIdentityId, featureStateId)
+            .then()
+            .statusCode(200);
+      } else {
+        throw new IllegalStateException("Unable to decide which feature-state to update: " + features);
+      }
+    }
+  }
+
+  public static void assignTraitToUserIdentity(String userIdentifier, String traitKey, Object traitValue, String apiKey) {
+    RestAssured.given()
+        .body(ImmutableMap.of(
+            "identity", ImmutableMap.of("identifier", userIdentifier),
+            "trait_key", traitKey,
+            "trait_value", traitValue
+        ))
+        .headers(defaultHeaders())
+        .header("x-environment-key", apiKey)
+        .post("/api/v1/traits/")
+        .then()
+        .statusCode(200);
+  }
+
+  public static int createProject(String name, int organisationId) {
+    return RestAssured.given()
+        .body(ImmutableMap.of(
+            "name", name,
+            "organisation", organisationId
+        ))
+        .headers(defaultHeaders())
+        .post("/api/v1/projects/")
+        .then()
+        .statusCode(201)
+        .extract()
+        .jsonPath()
+        .getInt("id");
+  }
+
+  public static Flag flag(String name, String description, boolean enabled) {
+    final com.flagsmith.Feature feature = new com.flagsmith.Feature();
+    feature.setName(name);
+    feature.setDescription(description);
+    feature.setType("FLAG");
+
+    final Flag result = new Flag();
+    result.setFeature(feature);
+    result.setEnabled(enabled);
+    return result;
+  }
+
+  public static Flag config(String name, String description, String value) {
+    final com.flagsmith.Feature feature = new com.flagsmith.Feature();
+    feature.setName(name);
+    feature.setDescription(description);
+    feature.setType("CONFIG");
+
+    final Flag result = new Flag();
+    result.setFeature(feature);
+    result.setStateValue(value);
+    return result;
+  }
+
+  public static Trait trait(String userIdentifier, String key, String value) {
+    final Trait result = new Trait();
+    if (userIdentifier != null) {
+      final FeatureUser user = featureUser(userIdentifier);
+      result.setIdentity(user);
+    }
+    result.setKey(key);
+    result.setValue(value);
+    return result;
+  }
+
+  public static FeatureUser featureUser(String identifier) {
+    final FeatureUser user = new FeatureUser();
+    user.setIdentifier(identifier);
+    return user;
+  }
+
+  public static abstract class Feature {
+    final String type;
+    final String name;
+    final String description;
+    final int projectId;
+
+    protected Feature(String type, String name, String description, int projectId) {
+      this.type = type;
+      this.name = name;
+      this.description = description;
+      this.projectId = projectId;
+    }
+  }
+
+  public static class FlagFeature extends Feature {
+    final boolean enabled;
+
+    protected FlagFeature(String name, String description, int projectId, boolean enabled) {
+      super("FLAG", name, description, projectId);
+      this.enabled = enabled;
+    }
+  }
+
+  public static class ConfigFeature extends Feature {
+    final String value;
+
+    protected ConfigFeature(String name, String description, int projectId, String value) {
+      super("CONFIG", name, description, projectId);
+      this.value = value;
+    }
+  }
+
+  public static class ProjectEnvironment {
+    final String apiKey;
+    final int projectId;
+    final FlagsmithClient client;
+
+    private ProjectEnvironment(String apiKey, int projectId, FlagsmithClient client) {
+      this.apiKey = apiKey;
+      this.projectId = projectId;
+      this.client = client;
+    }
+  }
+
+  public static Headers defaultHeaders() {
+    return new Headers(
+        new Header("Content-type", "application/json"),
+        new Header("Authorization", "Token " + IntegrationSuiteTest.TestData.token));
+  }
+}

--- a/src/test/java/com/flagsmith/IdentityTraitTest.java
+++ b/src/test/java/com/flagsmith/IdentityTraitTest.java
@@ -20,7 +20,7 @@ public class IdentityTraitTest {
             "  \n" +
             "]}";
 
-    @Test(groups = "integration")
+    @Test(groups = "unit")
     public void test_When_Parsed_Then_Success() throws IOException {
 
         IdentityTraits trait = new IdentityTraits();

--- a/src/test/java/com/flagsmith/IntegrationSuiteTest.java
+++ b/src/test/java/com/flagsmith/IntegrationSuiteTest.java
@@ -1,0 +1,102 @@
+package com.flagsmith;
+
+import com.google.common.collect.ImmutableMap;
+import io.restassured.RestAssured;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.utility.DockerImageName;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.Test;
+
+import static com.flagsmith.FlagsmithTestHelper.defaultHeaders;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(groups = "integration")
+public class IntegrationSuiteTest {
+
+  private static final Network network = Network.newNetwork();
+  private static PostgreSQLContainer<?> postgres;
+
+  public static final int BACKEND_PORT = 8000;
+
+  @BeforeGroups(groups = "integration")
+  public static void beforeClass() {
+    postgres = new PostgreSQLContainer<>(DockerImageName.parse("postgres:10.6-alpine"))
+        .withNetwork(network)
+        .withNetworkAliases("flagsmith-db")
+        .withDatabaseName("flagsmith")
+        .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("flagsmith-db")));
+    postgres.start();
+
+    TestData.backend = new GenericContainer<>(DockerImageName.parse("flagsmith/flagsmith-api:v2-5-2"))
+        .withNetwork(network)
+        .withNetworkAliases("flagsmith-be")
+        .withEnv("DJANGO_ALLOWED_HOSTS", "*")
+        .withEnv("DATABASE_URL", String.format("postgresql://%s:%s@%s:%d/%s",
+            postgres.getUsername(),
+            postgres.getPassword(),
+            "flagsmith-db",
+            PostgreSQLContainer.POSTGRESQL_PORT,
+            postgres.getDatabaseName()))
+        .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("flagsmith-be")))
+        .withExposedPorts(BACKEND_PORT)
+        .waitingFor(new HttpWaitStrategy().forPath("/health").withHeader("Accept", "application/json"));
+    TestData.backend.start();
+
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    RestAssured.port = TestData.backend.getMappedPort(BACKEND_PORT);
+
+    assertThat(RestAssured.get("/api/v1/users/init/").asString())
+        .describedAs("Super user have to be created")
+        .isEqualTo("ADMIN USER CREATED");
+
+    TestData.token = flagSmithAuthenticate();
+    TestData.organisationId = createOrganisation("Test Organisation");
+  }
+
+  @AfterGroups(groups = "integration")
+  public static void afterClass() {
+    TestData.backend.stop();
+    postgres.stop();
+    network.close();
+  }
+
+  private static String flagSmithAuthenticate() {
+    return RestAssured.given()
+        .body(ImmutableMap.of(
+            // from https://github.com/Flagsmith/flagsmith-api/blob/v2.5.0/src/app/settings/common.py#L255-L258
+            "email", "admin@example.com",
+            "password", "password"
+        ))
+        .header("Content-type", "application/json")
+        .post("/api/v1/auth/login/")
+        .then()
+        .statusCode(200)
+        .extract()
+        .jsonPath()
+        .getString("key");
+  }
+
+  private static int createOrganisation(String name) {
+    return RestAssured.given()
+        .body(ImmutableMap.of("name", name))
+        .headers(defaultHeaders())
+        .post("/api/v1/organisations/")
+        .then()
+        .statusCode(201)
+        .extract()
+        .jsonPath()
+        .getInt("id");
+  }
+
+  public static class TestData {
+    public static String token;
+    public static int organisationId;
+    public static GenericContainer<?> backend;
+  }
+}


### PR DESCRIPTION
Hi guys,

I have done 2 things in this PR:

- moved endpoints to a new class, so it is clearer to read
- Moved the running/stopping the docker containers to a BeforeGroups method. This way tests from the same group that are in different classes, can use the same container (instead of having to restart a new one every time).

Cheers,
Olga