### PR TITLE
Allow flags to be retrieved when identifying with traits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flagsmith</groupId>
     <artifactId>flagsmith-java-client</artifactId>
-    <version>3.0</version>
+    <version>2.8</version>
     <packaging>jar</packaging>
 
     <name>Flagsmith Java Client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flagsmith</groupId>
     <artifactId>flagsmith-java-client</artifactId>
-    <version>2.8</version>
+    <version>3.0</version>
     <packaging>jar</packaging>
 
     <name>Flagsmith Java Client</name>

--- a/src/main/java/com/flagsmith/FlagsmithClient.java
+++ b/src/main/java/com/flagsmith/FlagsmithClient.java
@@ -312,9 +312,9 @@ public class FlagsmithClient {
      *
      * @param user   a user in context
      * @param traits a list of Trait object to be created or updated
-     * @return a list of added Trait objects
+     * @return a `FlagsAndTraits` object
      */
-    public List<Trait> identifyUserWithTraits(FeatureUser user, List<Trait> traits) {
+    public FlagsAndTraits identifyUserWithTraits(FeatureUser user, List<Trait> traits) {
         return identifyUserWithTraits(user, traits, false);
     }
 
@@ -329,10 +329,10 @@ public class FlagsmithClient {
      * @param user   a user in context
      * @param traits a list of Trait object to be created or updated
      * @param doThrow throw exceptions or fail silently
-     * @return a list of added Trait objects
+     * @return a `FlagsAndTraits` object
      */
-    public List<Trait> identifyUserWithTraits(FeatureUser user, List<Trait> traits, boolean doThrow) {
-        return flagsmithSDK.identifyUserWithTraits(user, traits, doThrow).getTraits();
+    public FlagsAndTraits identifyUserWithTraits(FeatureUser user, List<Trait> traits, boolean doThrow) {
+        return flagsmithSDK.identifyUserWithTraits(user, traits, doThrow);
     }
 
     /**

--- a/src/main/java/com/flagsmith/FlagsmithClient.java
+++ b/src/main/java/com/flagsmith/FlagsmithClient.java
@@ -312,7 +312,7 @@ public class FlagsmithClient {
      *
      * @param user   a user in context
      * @param traits a list of Trait object to be created or updated
-     * @return a `FlagsAndTraits` object
+     * @return a FlagsAndTraits object
      */
     public FlagsAndTraits identifyUserWithTraits(FeatureUser user, List<Trait> traits) {
         return identifyUserWithTraits(user, traits, false);
@@ -329,7 +329,7 @@ public class FlagsmithClient {
      * @param user   a user in context
      * @param traits a list of Trait object to be created or updated
      * @param doThrow throw exceptions or fail silently
-     * @return a `FlagsAndTraits` object
+     * @return a FlagsAndTraits object
      */
     public FlagsAndTraits identifyUserWithTraits(FeatureUser user, List<Trait> traits, boolean doThrow) {
         return flagsmithSDK.identifyUserWithTraits(user, traits, doThrow);

--- a/src/test/java/com/flagsmith/FlagsmithCachedClientTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithCachedClientTest.java
@@ -346,7 +346,7 @@ public class FlagsmithCachedClientTest {
   public void testClient_When_Add_Traits_For_Identity_Then_Success() {
     List<Trait> traits = environment.client.identifyUserWithTraits(user2, Arrays.asList(
         trait(null, "trait_1", "some value1"),
-        trait(null, "trait_2", "some value2")));
+        trait(null, "trait_2", "some value2"))).getTraits();
     assertEquals(1, clientCache.estimatedSize());
     assertThat(traits)
         .hasSize(3)
@@ -359,7 +359,7 @@ public class FlagsmithCachedClientTest {
     traits = environment.client.identifyUserWithTraits(user2, Arrays.asList(
         trait(null, "trait_1", "updated value1"),
         trait(null, "trait_2", "updated value2"),
-        trait(null, "trait_3", "updated value3")));
+        trait(null, "trait_3", "updated value3"))).getTraits();
     assertEquals(1, clientCache.estimatedSize());
     assertThat(traits)
         .hasSize(4)

--- a/src/test/java/com/flagsmith/FlagsmithClientHttpErrorsTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithClientHttpErrorsTest.java
@@ -264,7 +264,7 @@ public class FlagsmithClientHttpErrorsTest {
         trait1.setValue("some value1");
 
         // When
-        List<Trait> traits = flagsmithClient.identifyUserWithTraits(null, Collections.singletonList(trait1));
+        List<Trait> traits = flagsmithClient.identifyUserWithTraits(null, Collections.singletonList(trait1)).getTraits();
 
         // Then
         // nothing return and exception thrown
@@ -286,7 +286,7 @@ public class FlagsmithClientHttpErrorsTest {
         trait2.setValue("some value2");
 
         // When
-        List<Trait> traits = flagsmithClient.identifyUserWithTraits(user,  Arrays.asList(trait1, trait2));
+        List<Trait> traits = flagsmithClient.identifyUserWithTraits(user,  Arrays.asList(trait1, trait2)).getTraits();
 
         // Then
         assertTrue(traits.isEmpty(), "Should not have traits returned");

--- a/src/test/java/com/flagsmith/FlagsmithClientTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithClientTest.java
@@ -445,7 +445,7 @@ public class FlagsmithClientTest {
 
         final List<Trait> traits = environment.client.identifyUserWithTraits(user, Arrays.asList(
                 trait(null, "trait_1", "some value1"),
-                trait(null, "trait_2", "some value2")));
+                trait(null, "trait_2", "some value2"))).getTraits();
 
         assertThat(traits)
                 .hasSize(2)
@@ -466,7 +466,7 @@ public class FlagsmithClientTest {
         List<Trait> traits = environment.client.identifyUserWithTraits(user, Arrays.asList(
             trait(null, "trait_1", "some value1"),
             trait(null, "trait_2", "some value2"),
-            trait(null, "trait_3", "some value3")));
+            trait(null, "trait_3", "some value3"))).getTraits();
 
         assertThat(traits)
             .hasSize(3)
@@ -480,7 +480,7 @@ public class FlagsmithClientTest {
         traits = environment.client.identifyUserWithTraits(user, Arrays.asList(
             trait(null, "extra_trait", "extra value"),
             trait(null, "trait_1", "updated value1"),
-            trait(null, "trait_3", "some value3")));
+            trait(null, "trait_3", "some value3"))).getTraits();
 
         assertThat(traits)
             .hasSize(4)

--- a/src/test/java/com/flagsmith/FlagsmithClientTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithClientTest.java
@@ -6,6 +6,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import com.flagsmith.FlagsmithTestHelper.FlagFeature;
+
 import static com.flagsmith.FlagsmithTestHelper.assignTraitToUserIdentity;
 import static com.flagsmith.FlagsmithTestHelper.config;
 import static com.flagsmith.FlagsmithTestHelper.createFeature;
@@ -18,6 +20,7 @@ import static com.flagsmith.FlagsmithTestHelper.switchFlagForUser;
 import static com.flagsmith.FlagsmithTestHelper.trait;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 /**
@@ -490,6 +493,38 @@ public class FlagsmithClientTest {
                 trait(null, "trait_2", "some value2"),
                 trait(null, "trait_3", "some value3")
             );
+    }
+
+    @Test(groups = "integration")
+    public void testClient_When_Identify_Then_Flags_And_Traits_Returned() {
+        final FlagsmithTestHelper.ProjectEnvironment environment = createProjectEnvironment(
+            "testClient_When_Identify_Then_Flags_And_Traits_Returned",
+            "TEST");
+
+        String featureName = "test_flag";
+        FlagFeature feature = new FlagsmithTestHelper.FlagFeature(
+                featureName, 
+                null, 
+                environment.projectId, 
+                false);
+        createFeature(feature);
+        
+        FeatureUser user = new FeatureUser();
+        user.setIdentifier("my-user");
+        Trait trait = new Trait(user, "trait_key", "trait_value");
+        List<Trait> traits = Arrays.asList(trait);
+
+        FlagsAndTraits flagsAndTraits = environment.client.identifyUserWithTraits(user, traits);
+
+        List<Trait> returnedTraits = flagsAndTraits.getTraits();
+        List<Flag> returnedFlags = flagsAndTraits.getFlags();
+
+        Trait expectedTrait = new Trait(null, trait.getKey(), trait.getValue());
+        assertThat(returnedTraits).hasSize(1);
+        assertEquals(expectedTrait, returnedTraits.get(0));
+
+        assertThat(returnedFlags).hasSize(1);
+        assertEquals(returnedFlags.get(0).getFeature().getName(), featureName);
     }
 
     @Test(groups = "integration")


### PR DESCRIPTION
At the moment, although it's possibel to identify a user with their traits, it's not possible to subsequently access the returned flags. This change updates the interface of the flagsmith client to return the full FlagsAndTraits object so that both flags and traits can be accessed. 