### PR TITLE
Add parameterized constructor to FeatureUser

### DIFF
--- a/src/main/java/com/flagsmith/FeatureUser.java
+++ b/src/main/java/com/flagsmith/FeatureUser.java
@@ -1,11 +1,15 @@
 package com.flagsmith;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Representation of the Identity user.
  */
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class FeatureUser {
 
   private String identifier;


### PR DESCRIPTION
It would be nice to have a parameterized constructor for the `FeatureUser` class so it can be used in one-liners such as:

```java
flagsmithClient.hasFeatureFlag("my_test_feature", new FeatureUser("some-user"));
```