### PR TITLE
Add ability to include an optional proxy on the Http Client

### DIFF
--- a/src/main/java/com/flagsmith/config/FlagsmithConfig.java
+++ b/src/main/java/com/flagsmith/config/FlagsmithConfig.java
@@ -4,6 +4,8 @@ import com.flagsmith.FlagsmithClient;
 import com.flagsmith.FlagsmithFlagDefaults;
 import com.flagsmith.interfaces.DefaultFlagHandler;
 import com.flagsmith.threads.AnalyticsProcessor;
+
+import java.net.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +59,9 @@ public final class FlagsmithConfig {
     for (final Interceptor interceptor : builder.interceptors) {
       httpBuilder = httpBuilder.addInterceptor(interceptor);
     }
+    if (builder.proxy != null) {
+      httpBuilder = httpBuilder.proxy(builder.proxy);
+    }
     this.httpClient = httpBuilder.build();
 
     this.retries = builder.retries;
@@ -79,6 +84,7 @@ public final class FlagsmithConfig {
   public static class Builder {
 
     private final List<Interceptor> interceptors = new ArrayList<>();
+    private Proxy proxy;
     private HttpUrl baseUri = DEFAULT_BASE_URI;
     private int connectTimeoutMillis = DEFAULT_CONNECT_TIMEOUT_MILLIS;
     private int writeTimeoutMillis = DEFAULT_WRITE_TIMEOUT_MILLIS;
@@ -164,6 +170,17 @@ public final class FlagsmithConfig {
      */
     public Builder addHttpInterceptor(Interceptor interceptor) {
       this.interceptors.add(interceptor);
+      return this;
+    }
+
+    /**
+     * Add a Proxy to the HttpClient.
+     *
+     * @param proxy the proxy
+     * @return the Builder
+     */
+    public Builder withProxy(Proxy proxy) {
+      this.proxy = proxy;
       return this;
     }
 

--- a/src/test/java/com/flagsmith/config/FlagsmithConfigTest.java
+++ b/src/test/java/com/flagsmith/config/FlagsmithConfigTest.java
@@ -1,9 +1,13 @@
 package com.flagsmith.config;
 
+import static org.junit.Assert.assertNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import com.flagsmith.config.FlagsmithConfig;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import okhttp3.mock.MockInterceptor;
 import org.testng.annotations.Test;
 
@@ -17,21 +21,26 @@ public class FlagsmithConfigTest {
     assertEquals(5000, flagsmithConfig.getHttpClient().readTimeoutMillis());
     assertEquals(5000, flagsmithConfig.getHttpClient().writeTimeoutMillis());
     assertEquals(2000, flagsmithConfig.getHttpClient().connectTimeoutMillis());
+    assertNull(flagsmithConfig.getHttpClient().proxy());
   }
 
   @Test(groups = "unit")
   public void configTest_custom() {
+    Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("proxy", 1234));
+
     final FlagsmithConfig flagsmithConfig = FlagsmithConfig.newBuilder()
         .addHttpInterceptor(new MockInterceptor())
         .connectTimeout(1234)
         .readTimeout(3333)
         .writeTimeout(6666)
+        .withProxy(proxy)
         .build();
 
     assertEquals(1, flagsmithConfig.getHttpClient().interceptors().size());
     assertEquals(3333, flagsmithConfig.getHttpClient().readTimeoutMillis());
     assertEquals(6666, flagsmithConfig.getHttpClient().writeTimeoutMillis());
     assertEquals(1234, flagsmithConfig.getHttpClient().connectTimeoutMillis());
+    assertEquals(proxy, flagsmithConfig.getHttpClient().proxy());
   }
 
   @Test(groups = "unit")


### PR DESCRIPTION
Adds method to the Flagsmith builder to include a `java.net.Proxy` object which will be added to the OkHttpClient. 