### PR TITLE
Fix semver javadoc

### DIFF
--- a/src/main/java/com/flagsmith/flagengine/utils/SemanticVersioning.java
+++ b/src/main/java/com/flagsmith/flagengine/utils/SemanticVersioning.java
@@ -3,11 +3,13 @@ package com.flagsmith.flagengine.utils;
 public class SemanticVersioning {
 
   /**
-   * Checks if the given string have `:semver` suffix or not
-   *     >>> is_semver("2.1.41-beta:semver")
-   *     True
-   *     >>> is_semver("2.1.41-beta")
-   *     False
+   * Checks if the given string have `:semver` suffix or not.
+   * <pre>{@code
+   *    >>> is_semver("2.1.41-beta:semver")
+   *    True
+   *    >>> is_semver("2.1.41-beta")
+   *    False
+   * }</pre>
    * @param version The version string.
    * @return
    */
@@ -16,11 +18,13 @@ public class SemanticVersioning {
   }
 
   /**
-   * Remove the semver suffix(i.e: last 7 characters) from the given value
+   * Remove the semver suffix(i.e: last 7 characters) from the given value.
+   * <pre>{@code
    *     >>> remove_semver_suffix("2.1.41-beta:semver")
    *     '2.1.41-beta'
    *     >>> remove_semver_suffix("2.1.41:semver")
    *     '2.1.41'
+   * }</pre>
    * @param version the version string to strip version from.
    * @return
    */


### PR DESCRIPTION
The previous javadoc caused a hard failure (since javadoc works in HTML so needs '>' symbols to be escaped). 