### PR TITLE
Use default flags in local evaluation mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,6 @@
 
     <!-- Test Dependencies-->
     <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <version>7.6.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>

--- a/src/main/java/com/flagsmith/FlagsmithClient.java
+++ b/src/main/java/com/flagsmith/FlagsmithClient.java
@@ -37,10 +37,10 @@ public class FlagsmithClient {
   private FlagsmithSdk flagsmithSdk;
   private EnvironmentModel environment;
   private PollingManager pollingManager;
-  private static final String UNABLE_TO_UPDATE_ENVIRONMENT_MESSAGE =
-          "Unable to update environment from API. Continuing to use previous copy.";
+  private static final String UNABLE_TO_UPDATE_ENVIRONMENT_MESSAGE = "Unable to update environment from API. Continuing to use previous copy.";
 
-  private FlagsmithClient() { }
+  private FlagsmithClient() {
+  }
 
   public static FlagsmithClient.Builder newBuilder() {
     return new FlagsmithClient.Builder();
@@ -81,7 +81,8 @@ public class FlagsmithClient {
   /**
    * Get all the flags for the current environment for a given identity. Will also
    * upsert all traits to the Flagsmith API for future evaluations. Providing a
-   * trait with a value of None will remove the trait from the identity if it exists.
+   * trait with a value of None will remove the trait from the identity if it
+   * exists.
    *
    * @param identifier identifier string
    * @return
@@ -94,10 +95,11 @@ public class FlagsmithClient {
   /**
    * Get all the flags for the current environment for a given identity. Will also
    * upsert all traits to the Flagsmith API for future evaluations. Providing a
-   * trait with a value of None will remove the trait from the identity if it exists.
+   * trait with a value of None will remove the trait from the identity if it
+   * exists.
    *
    * @param identifier identifier string
-   * @param traits list of key value traits
+   * @param traits     list of key value traits
    * @return
    */
   public Flags getIdentityFlags(String identifier, Map<String, Object> traits)
@@ -113,7 +115,7 @@ public class FlagsmithClient {
    * Get a list of segments that the given identity is in.
    *
    * @param identifier a unique identifier for the identity in the current
-   *             environment, e.g. email address, username, uuid
+   *                   environment, e.g. email address, username, uuid
    * @return
    */
   public List<Segment> getIdentitySegments(String identifier)
@@ -125,9 +127,9 @@ public class FlagsmithClient {
    * Get a list of segments that the given identity is in.
    *
    * @param identifier a unique identifier for the identity in the current
-   *             environment, e.g. email address, username, uuid
-   * @param traits a dictionary of traits to add / update on the identity in
-   *             Flagsmith, e.g. {"num_orders": 10}
+   *                   environment, e.g. email address, username, uuid
+   * @param traits     a dictionary of traits to add / update on the identity in
+   *                   Flagsmith, e.g. {"num_orders": 10}
    * @return
    */
   public List<Segment> getIdentitySegments(String identifier, Map<String, Object> traits)
@@ -136,11 +138,9 @@ public class FlagsmithClient {
       throw new FlagsmithClientError("Local evaluation required to obtain identity segments.");
     }
     IdentityModel identityModel = buildIdentityModel(
-        identifier, (traits != null ? traits : new HashMap<>())
-    );
+        identifier, (traits != null ? traits : new HashMap<>()));
     List<SegmentModel> segmentModels = SegmentEvaluator.getIdentitySegments(
-        environment, identityModel
-    );
+        environment, identityModel);
 
     return segmentModels.stream().map((segmentModel) -> {
       Segment segment = new Segment();
@@ -152,8 +152,9 @@ public class FlagsmithClient {
   }
 
   /**
-   * Should be called when terminating the client to clean up any resources that need cleaning up.
-  **/
+   * Should be called when terminating the client to clean up any resources that
+   * need cleaning up.
+   **/
   public void close() {
     if (pollingManager != null) {
       pollingManager.stopPolling();
@@ -173,18 +174,17 @@ public class FlagsmithClient {
         Engine.getEnvironmentFeatureStates(environment),
         flagsmithSdk.getConfig().getAnalyticsProcessor(),
         null,
-        flagsmithSdk.getConfig().getFlagsmithFlagDefaults()
-      );
+        flagsmithSdk.getConfig().getFlagsmithFlagDefaults());
   }
 
   private Flags getIdentityFlagsFromDocument(String identifier, Map<String, Object> traits)
       throws FlagsmithClientError {
-      if (environment == null) {
-        if (flagsmithSdk.getConfig().getFlagsmithFlagDefaults() == null) {
-          throw new FlagsmithClientError("Unable to get flags. No environment present.");
-        }
-        return getDefaultFlags();
+    if (environment == null) {
+      if (flagsmithSdk.getConfig().getFlagsmithFlagDefaults() == null) {
+        throw new FlagsmithClientError("Unable to get flags. No environment present.");
       }
+      return getDefaultFlags();
+    }
 
     IdentityModel identity = buildIdentityModel(identifier, traits);
     List<FeatureStateModel> featureStates = Engine.getIdentityFeatureStates(environment, identity);
@@ -193,8 +193,7 @@ public class FlagsmithClient {
         featureStates,
         flagsmithSdk.getConfig().getAnalyticsProcessor(),
         identity.getCompositeKey(),
-        flagsmithSdk.getConfig().getFlagsmithFlagDefaults()
-    );
+        flagsmithSdk.getConfig().getFlagsmithFlagDefaults());
   }
 
   private Flags getEnvironmentFlagsFromApi() throws FlagsmithApiError {
@@ -223,8 +222,7 @@ public class FlagsmithClient {
       return flagsmithSdk.identifyUserWithTraits(
           identifier,
           traitsList,
-          Boolean.TRUE
-      );
+          Boolean.TRUE);
     } catch (Exception e) {
       if (flagsmithSdk.getConfig().getFlagsmithFlagDefaults() != null) {
         return getDefaultFlags();
@@ -237,8 +235,7 @@ public class FlagsmithClient {
   private IdentityModel buildIdentityModel(String identifier, Map<String, Object> traits)
       throws FlagsmithClientError {
     if (environment == null) {
-      throw new
-          FlagsmithClientError("Unable to build identity model when no local environment present.");
+      throw new FlagsmithClientError("Unable to build identity model when no local environment present.");
     }
 
     List<TraitModel> traitsList = traits.entrySet().stream().map((entry) -> {
@@ -264,7 +261,8 @@ public class FlagsmithClient {
   }
 
   /**
-   * Returns a FlagsmithCache cache object that encapsulates methods to manipulate the cache.
+   * Returns a FlagsmithCache cache object that encapsulates methods to manipulate
+   * the cache.
    *
    * @return a FlagsmithCache if enabled, otherwise null.
    */
@@ -302,13 +300,17 @@ public class FlagsmithClient {
     }
 
     /**
-     * When a flag does not exist in Flagsmith or there is an error, the SDK will return null by
+     * When a flag does not exist in Flagsmith or there is an error, the SDK will
+     * return null by
      * default.
      *
-     * <p>If you would like to override this default behaviour, you can use this method. By default
+     * <p>
+     * If you would like to override this default behaviour, you can use this
+     * method. By default
      * it will return null for any flags that it does not recognise.
      *
-     * @param defaultFlagValueFunction the new function to use as default flag values
+     * @param defaultFlagValueFunction the new function to use as default flag
+     *                                 values
      * @return the Builder
      */
     public Builder setDefaultFlagValueFunction(
@@ -322,7 +324,8 @@ public class FlagsmithClient {
     }
 
     /**
-     * Enables logging, the project importing this module must include an implementation slf4j in
+     * Enables logging, the project importing this module must include an
+     * implementation slf4j in
      * their pom.
      *
      * @param level log error level.
@@ -334,7 +337,8 @@ public class FlagsmithClient {
     }
 
     /**
-     * Enables logging, the project importing this module must include an implementation slf4j in
+     * Enables logging, the project importing this module must include an
+     * implementation slf4j in
      * their pom.
      *
      * @return the Builder
@@ -386,7 +390,9 @@ public class FlagsmithClient {
     /**
      * Enable in-memory caching for the Flagsmith API.
      *
-     * <p>If no other cache configuration is set, the Caffeine defaults will be used, i.e. no limit
+     * <p>
+     * If no other cache configuration is set, the Caffeine defaults will be used,
+     * i.e. no limit
      *
      * @param cacheConfig an FlagsmithCacheConfig.
      * @return the Builder
@@ -430,19 +436,17 @@ public class FlagsmithClient {
         flagsmithApiWrapper = this.flagsmithApiWrapper;
       } else if (cacheConfig != null) {
         flagsmithApiWrapper = new FlagsmithApiWrapper(
-                cacheConfig.getCache(),
-                this.configuration,
-                this.customHeaders,
-                client.logger,
-                apiKey
-        );
+            cacheConfig.getCache(),
+            this.configuration,
+            this.customHeaders,
+            client.logger,
+            apiKey);
       } else {
         flagsmithApiWrapper = new FlagsmithApiWrapper(
-                this.configuration,
-                this.customHeaders,
-                client.logger,
-                apiKey
-        );
+            this.configuration,
+            this.customHeaders,
+            client.logger,
+            apiKey);
       }
 
       client.flagsmithSdk = flagsmithApiWrapper;
@@ -456,8 +460,7 @@ public class FlagsmithClient {
         if (!apiKey.startsWith("ser.")) {
           throw new RuntimeException(
               "In order to use local evaluation, please generate a server key "
-              + "in the environment settings page."
-          );
+                  + "in the environment settings page.");
         }
 
         if (this.pollingManager != null) {
@@ -465,8 +468,7 @@ public class FlagsmithClient {
         } else {
           client.pollingManager = new PollingManager(
               client,
-              configuration.getEnvironmentRefreshIntervalSeconds()
-          );
+              configuration.getEnvironmentRefreshIntervalSeconds());
         }
 
         client.pollingManager.startPolling();

--- a/src/main/java/com/flagsmith/FlagsmithClient.java
+++ b/src/main/java/com/flagsmith/FlagsmithClient.java
@@ -1,6 +1,5 @@
 package com.flagsmith;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.flagsmith.config.FlagsmithCacheConfig;
 import com.flagsmith.config.FlagsmithConfig;
 import com.flagsmith.exceptions.FlagsmithApiError;
@@ -17,16 +16,11 @@ import com.flagsmith.interfaces.FlagsmithSdk;
 import com.flagsmith.models.BaseFlag;
 import com.flagsmith.models.Flags;
 import com.flagsmith.models.Segment;
-import com.flagsmith.threads.AnalyticsProcessor;
 import com.flagsmith.threads.PollingManager;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import lombok.Data;

--- a/src/main/java/com/flagsmith/FlagsmithClient.java
+++ b/src/main/java/com/flagsmith/FlagsmithClient.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import lombok.Data;
 import lombok.NonNull;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -37,8 +38,6 @@ public class FlagsmithClient {
   private FlagsmithSdk flagsmithSdk;
   private EnvironmentModel environment;
   private PollingManager pollingManager;
-  private static final String UNABLE_TO_UPDATE_ENVIRONMENT_MESSAGE =
-          "Unable to update environment from API. Continuing to use previous copy.";
 
   private FlagsmithClient() {
   }
@@ -59,10 +58,10 @@ public class FlagsmithClient {
       if (updatedEnvironment != null) {
         this.environment = updatedEnvironment;
       } else {
-        logger.error(UNABLE_TO_UPDATE_ENVIRONMENT_MESSAGE);
+        logger.error(getEnvironmentUpdateErrorMessage());
       }
     } catch (RuntimeException e) {
-      logger.error(UNABLE_TO_UPDATE_ENVIRONMENT_MESSAGE);
+      logger.error(getEnvironmentUpdateErrorMessage());
     }
   }
 
@@ -262,6 +261,14 @@ public class FlagsmithClient {
     return flags;
   }
 
+  private String getEnvironmentUpdateErrorMessage() {
+    if (this.environment == null) {
+      return "Unable to update environment from API. No environment configured - using defaultHandler if configured.";
+    } else {
+      return "Unable to update environment from API. Continuing to use previous copy.";
+    }
+  }
+
   /**
    * Returns a FlagsmithCache cache object that encapsulates methods to manipulate
    * the cache.
@@ -346,6 +353,18 @@ public class FlagsmithClient {
      */
     public Builder enableLogging() {
       this.client.logger.setLogger(LoggerFactory.getLogger(FlagsmithClient.class));
+      return this;
+    }
+
+    /**
+     * Enables logging, the project importing this module must include an
+     * implementation slf4j in
+     * their pom.
+     *
+     * @return the Builder
+     */
+    public Builder enableLogging(Logger logger) {
+      this.client.logger.setLogger(logger);
       return this;
     }
 

--- a/src/main/java/com/flagsmith/FlagsmithClient.java
+++ b/src/main/java/com/flagsmith/FlagsmithClient.java
@@ -161,8 +161,11 @@ public class FlagsmithClient {
     flagsmithSdk.close();
   }
 
-  private Flags getEnvironmentFlagsFromDocument() {
+  private Flags getEnvironmentFlagsFromDocument() throws FlagsmithClientError {
     if (environment == null) {
+      if (flagsmithSdk.getConfig().getFlagsmithFlagDefaults() == null) {
+        throw new FlagsmithClientError("Unable to get flags. No environment present.");
+      }
       return getDefaultFlags();
     }
 
@@ -176,9 +179,12 @@ public class FlagsmithClient {
 
   private Flags getIdentityFlagsFromDocument(String identifier, Map<String, Object> traits)
       throws FlagsmithClientError {
-    if (environment == null) {
-      return getDefaultFlags();
-    }
+      if (environment == null) {
+        if (flagsmithSdk.getConfig().getFlagsmithFlagDefaults() == null) {
+          throw new FlagsmithClientError("Unable to get flags. No environment present.");
+        }
+        return getDefaultFlags();
+      }
 
     IdentityModel identity = buildIdentityModel(identifier, traits);
     List<FeatureStateModel> featureStates = Engine.getIdentityFeatureStates(environment, identity);

--- a/src/main/java/com/flagsmith/FlagsmithClient.java
+++ b/src/main/java/com/flagsmith/FlagsmithClient.java
@@ -37,7 +37,8 @@ public class FlagsmithClient {
   private FlagsmithSdk flagsmithSdk;
   private EnvironmentModel environment;
   private PollingManager pollingManager;
-  private static final String UNABLE_TO_UPDATE_ENVIRONMENT_MESSAGE = "Unable to update environment from API. Continuing to use previous copy.";
+  private static final String UNABLE_TO_UPDATE_ENVIRONMENT_MESSAGE =
+          "Unable to update environment from API. Continuing to use previous copy.";
 
   private FlagsmithClient() {
   }
@@ -70,7 +71,7 @@ public class FlagsmithClient {
    *
    * @return
    */
-  public Flags getEnvironmentFlags() throws FlagsmithApiError {
+  public Flags getEnvironmentFlags() throws FlagsmithClientError {
     if (flagsmithSdk.getConfig().getEnableLocalEvaluation()) {
       return getEnvironmentFlagsFromDocument();
     }
@@ -235,7 +236,8 @@ public class FlagsmithClient {
   private IdentityModel buildIdentityModel(String identifier, Map<String, Object> traits)
       throws FlagsmithClientError {
     if (environment == null) {
-      throw new FlagsmithClientError("Unable to build identity model when no local environment present.");
+      throw new FlagsmithClientError(
+        "Unable to build identity model when no local environment present.");
     }
 
     List<TraitModel> traitsList = traits.entrySet().stream().map((entry) -> {
@@ -304,8 +306,7 @@ public class FlagsmithClient {
      * return null by
      * default.
      *
-     * <p>
-     * If you would like to override this default behaviour, you can use this
+     * <p>If you would like to override this default behaviour, you can use this
      * method. By default
      * it will return null for any flags that it does not recognise.
      *
@@ -390,8 +391,7 @@ public class FlagsmithClient {
     /**
      * Enable in-memory caching for the Flagsmith API.
      *
-     * <p>
-     * If no other cache configuration is set, the Caffeine defaults will be used,
+     * <p>If no other cache configuration is set, the Caffeine defaults will be used,
      * i.e. no limit
      *
      * @param cacheConfig an FlagsmithCacheConfig.

--- a/src/main/java/com/flagsmith/FlagsmithClient.java
+++ b/src/main/java/com/flagsmith/FlagsmithClient.java
@@ -263,7 +263,8 @@ public class FlagsmithClient {
 
   private String getEnvironmentUpdateErrorMessage() {
     if (this.environment == null) {
-      return "Unable to update environment from API. No environment configured - using defaultHandler if configured.";
+      return "Unable to update environment from API. "
+             + "No environment configured - using defaultHandler if configured.";
     } else {
       return "Unable to update environment from API. Continuing to use previous copy.";
     }

--- a/src/main/java/com/flagsmith/config/FlagsmithConfig.java
+++ b/src/main/java/com/flagsmith/config/FlagsmithConfig.java
@@ -42,6 +42,7 @@ public final class FlagsmithConfig {
   private Integer environmentRefreshIntervalSeconds;
   private AnalyticsProcessor analyticsProcessor;
   private FlagsmithFlagDefaults flagsmithFlagDefaults = null;
+  private Boolean raiseUpdateEnvironmentErrorsOnStartup = true;
 
   protected FlagsmithConfig(Builder builder) {
     this.baseUri = builder.baseUri;

--- a/src/test/java/com/flagsmith/FlagsmithClientTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithClientTest.java
@@ -37,635 +37,637 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
- * Unit tests are env specific and will probably will need to adjust keys, identities and features
+ * Unit tests are env specific and will probably will need to adjust keys,
+ * identities and features
  * ids etc as required.
  */
 @Test(groups = "unit")
 public class FlagsmithClientTest {
 
-  private static String DEFAULT_FLAG_VALUE = "foobar";
-  private static boolean DEFAULT_FLAG_STATE = true;
-
-  private static BaseFlag defaultHandler(String featureName) {
-    DefaultFlag defaultFlag = new DefaultFlag();
-    defaultFlag.setEnabled(DEFAULT_FLAG_STATE);
-    defaultFlag.setValue(DEFAULT_FLAG_VALUE);
-    defaultFlag.setFeatureName(featureName);
-    return defaultFlag;
-  }
-
-  @Test(groups = "unit")
-  public void testClient_When_Cache_Disabled_Return_Null() {
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .setApiKey("api-key")
-        .build();
-
-    FlagsmithCache cache = client.getCache();
-
-    Assert.assertNull(cache);
-  }
-
-  @Test(groups = "unit")
-  public void testClient_validateObjectCreation() throws InterruptedException {
-    PollingManager manager = mock(PollingManager.class);
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withPollingManager(manager)
-        .withConfiguration(
-            FlagsmithConfig.newBuilder().withLocalEvaluation(Boolean.TRUE).build()
-        )
-        .setApiKey("ser.abcdefg")
-        .build();
-
-    Thread.sleep(10);
-    verify(manager, times(1)).startPolling();
-  }
-
-  @Test(groups = "unit")
-  public void testLocalEvaluationRequiresServerKey() throws InterruptedException {
-    Assert.assertThrows(RuntimeException.class, () -> FlagsmithClient.newBuilder()
-        .withConfiguration(
-            FlagsmithConfig.newBuilder().withLocalEvaluation(Boolean.TRUE).build()
-        )
-        .setApiKey("not-a-server-key")
-        .build());
-  }
-
-  @Test(groups = "unit")
-  public void testClient_errorEnvironmentApi() {
-    String baseUrl = "http://bad-url";
-    MockInterceptor interceptor = new MockInterceptor();
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withConfiguration(
-            FlagsmithConfig.newBuilder()
-                .baseUri(baseUrl)
-                .addHttpInterceptor(interceptor)
-                .build()
-        ).setApiKey("api-key")
-        .build();
-
-    interceptor.addRule()
-        .get(baseUrl + "/environment-document/")
-        .respond(
-            500,
-            ResponseBody.create("error", MEDIATYPE_JSON)
-        );
-
-    Assert.assertThrows(Exception.class, () -> client.updateEnvironment());
-  }
-
-  @Test(groups = "unit")
-  public void testClient_validateEnvironment()
-      throws JsonProcessingException {
-    String baseUrl = "http://bad-url";
-    MockInterceptor interceptor = new MockInterceptor();
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withConfiguration(
-            FlagsmithConfig.newBuilder()
-                .baseUri(baseUrl)
-                .addHttpInterceptor(interceptor)
-                .build()
-        ).setApiKey("api-key")
-        .build();
-
-    EnvironmentModel environmentModel = FlagsmithTestHelper.environmentModel();
-
-    interceptor.addRule()
-        .get(baseUrl + "/environment-document/")
-        .anyTimes()
-        .respond(
-            MapperFactory.getMapper().writeValueAsString(environmentModel),
-            MEDIATYPE_JSON
-        );
-
-    client.updateEnvironment();
-    Assert.assertNotNull(client.getEnvironment());
-    Assert.assertEquals(client.getEnvironment(), environmentModel);
-  }
-
-  @Test(groups = "unit")
-  public void testClient_flagsApiException()
-      throws FlagsmithApiError {
-    String baseUrl = "http://bad-url";
-    MockInterceptor interceptor = new MockInterceptor();
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withConfiguration(
-            FlagsmithConfig.newBuilder()
-                .baseUri(baseUrl)
-                .addHttpInterceptor(interceptor)
-                .build()
-        ).setApiKey("api-key")
-        .build();
-
-    interceptor.addRule()
-        .get(baseUrl + "/flags/")
-        .respond(
-            500,
-            ResponseBody.create("error", MEDIATYPE_JSON)
-        );
-
-    Assert.assertThrows(FlagsmithApiError.class, () -> client.getEnvironmentFlags());
-  }
-
-  @Test(groups = "unit")
-  public void testClient_flagsApiEmpty()
-      throws FlagsmithApiError {
-    String baseUrl = "http://bad-url";
-    MockInterceptor interceptor = new MockInterceptor();
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withConfiguration(
-            FlagsmithConfig.newBuilder()
-                .baseUri(baseUrl)
-                .addHttpInterceptor(interceptor)
-                .build()
-        ).setApiKey("api-key")
-        .build();
-
-    interceptor.addRule()
-        .get(baseUrl + "/flags/")
-        .respond(
-            "[]",
-            MEDIATYPE_JSON
-        );
-
-    Assert.assertNotNull(client);
-    List<BaseFlag> flags = client.getEnvironmentFlags().getAllFlags();
-    Assert.assertTrue(flags.isEmpty());
-  }
-
-  @Test(groups = "unit")
-  public void testClient_flagsApi()
-      throws JsonProcessingException, FlagsmithApiError {
-    String baseUrl = "http://bad-url";
-    MockInterceptor interceptor = new MockInterceptor();
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withConfiguration(
-            FlagsmithConfig.newBuilder()
-                .baseUri(baseUrl)
-                .addHttpInterceptor(interceptor)
-                .build()
-        ).setApiKey("api-key")
-        .build();
-
-    List<FeatureStateModel> featureStateModel = FlagsmithTestHelper.getFlags();
-
-    interceptor.addRule()
-        .get(baseUrl + "/flags/")
-        .respond(
-            MapperFactory.getMapper().writeValueAsString(featureStateModel),
-            MEDIATYPE_JSON
-        );
-
-    List<BaseFlag> flags = client.getEnvironmentFlags().getAllFlags();
-    Assert.assertEquals(flags.get(0).getEnabled(), Boolean.TRUE);
-    Assert.assertEquals(flags.get(0).getValue(), "some-value");
-    Assert.assertEquals(flags.get(0).getFeatureName(), "some_feature");
-  }
-
-  @Test(groups = "unit")
-  public void testClient_identityFlagsApiNoTraitsException() throws FlagsmithClientError {
-    String baseUrl = "http://bad-url";
-    String identifier = "identifier";
-    MockInterceptor interceptor = new MockInterceptor();
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withConfiguration(
-            FlagsmithConfig.newBuilder()
-                .baseUri(baseUrl)
-                .addHttpInterceptor(interceptor)
-                .build()
-        ).setApiKey("api-key")
-        .build();
-
-    interceptor.addRule()
-        .post(baseUrl + "/identities/")
-        .respond(
-            500,
-            ResponseBody.create("error", MEDIATYPE_JSON)
-        );
-
-    Assert.assertThrows(FlagsmithApiError.class, () -> client.getIdentityFlags(identifier));
-  }
-
-  @Test(groups = "unit")
-  public void testClient_identityFlagsApiNoTraits() throws FlagsmithClientError {
-    String baseUrl = "http://bad-url";
-    String identifier = "identifier";
-    MockInterceptor interceptor = new MockInterceptor();
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withConfiguration(
-            FlagsmithConfig.newBuilder()
-                .baseUri(baseUrl)
-                .addHttpInterceptor(interceptor)
-                .build()
-        ).setApiKey("api-key")
-        .build();
-
-    String json = FlagsmithTestHelper.getIdentitiesFlags();
-
-    interceptor.addRule()
-        .post(baseUrl + "/identities/")
-        .respond(
-            json,
-            MEDIATYPE_JSON
-        );
-
-    List<BaseFlag> flags = client.getIdentityFlags(identifier).getAllFlags();
-    Assert.assertEquals(flags.get(0).getEnabled(), Boolean.TRUE);
-    Assert.assertEquals(flags.get(0).getValue(), "some-value");
-    Assert.assertEquals(flags.get(0).getFeatureName(), "some_feature");
-  }
-
-  @Test(groups = "unit")
-  public void testClient_identityFlagsApiWithTraits()
-      throws FlagsmithClientError, IOException {
-    String baseUrl = "http://bad-url";
-    String identifier = "identifier";
-    Map<String, Object> traits = new HashMap<String, Object>() {{
-      put("some_trait", "some_value");
-    }};
-    MockInterceptor interceptor = new MockInterceptor();
-    RequestProcessor requestProcessor = mock(RequestProcessor.class);
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withConfiguration(
-            FlagsmithConfig.newBuilder()
-                .baseUri(baseUrl)
-                .addHttpInterceptor(interceptor)
-                .build()
-        ).setApiKey("api-key")
-        .build();
-    // mocking the requestor
-    ((FlagsmithApiWrapper) client.getFlagsmithSdk()).setRequestor(requestProcessor);
-    String json = FlagsmithTestHelper.getIdentitiesFlags();
-    TypeReference<FlagsAndTraitsResponse> tr = new TypeReference<FlagsAndTraitsResponse>() {};
-
-    when(requestProcessor.executeAsync(any(), any(), any()))
-        .thenReturn(
-            FlagsmithTestHelper.futurableReturn(MapperFactory.getMapper().readValue(json, tr)));
-
-    List<BaseFlag> flags = client.getIdentityFlags(identifier, traits).getAllFlags();
-
-    ArgumentCaptor<Request> argument = ArgumentCaptor.forClass(Request.class);
-    verify(requestProcessor, times(1)).executeAsync(argument.capture(), any(), any());
-
-    Buffer buffer = new Buffer();
-    argument.getValue().body().writeTo(buffer);
-
-    JsonNode expectedRequest = FlagsmithTestHelper.getIdentityRequest(identifier, new ArrayList<TraitModel>() {{
-      add(new TraitModel("some_trait", "some_value"));
-    }});
-
-    Assert.assertEquals(expectedRequest.toString(), buffer.readUtf8());
-    Assert.assertEquals(flags.get(0).getEnabled(), Boolean.TRUE);
-    Assert.assertEquals(flags.get(0).getValue(), "some-value");
-    Assert.assertEquals(flags.get(0).getFeatureName(), "some_feature");
-  }
-
-  @Test(groups = "unit")
-  public void testClient_identityFlagsApiWithTraitsWithLocalEnvironment() {
-    String baseUrl = "http://bad-url";
-    String identifier = "identifier";
-    Map<String, Object> traits = new HashMap<String, Object>() {{
-      put("some_trait", "some_value");
-    }};
-    MockInterceptor interceptor = new MockInterceptor();
-    RequestProcessor requestProcessor = mock(RequestProcessor.class);
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withConfiguration(
-            FlagsmithConfig.newBuilder()
-                .baseUri(baseUrl)
-                .addHttpInterceptor(interceptor)
-                .build()
-        ).setApiKey("api-key")
-        .build();
-
-    interceptor.addRule()
-        .get(baseUrl + "/flags/").anyTimes()
-        .respond(500, ResponseBody.create("error", MEDIATYPE_JSON));
-
-    assertThrows(FlagsmithApiError.class,
-        () -> client.getEnvironmentFlags());
-  }
-
-  @Test(groups = "unit")
-  public void testClient_defaultFlagWithNoEnvironment() throws FlagsmithClientError {
-    String baseUrl = "http://bad-url";
-    String identifier = "identifier";
-    Map<String, Object> traits = new HashMap<String, Object>() {{
-      put("some_trait", "some_value");
-    }};
-    MockInterceptor interceptor = new MockInterceptor();
-    RequestProcessor requestProcessor = mock(RequestProcessor.class);
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withConfiguration(
-            FlagsmithConfig.newBuilder()
-                .baseUri(baseUrl)
-                .addHttpInterceptor(interceptor)
-                .build()
-        )
-        .setApiKey("api-key")
-        .setDefaultFlagValueFunction((name) -> {
-          DefaultFlag flag = new DefaultFlag();
-          flag.setValue("some-value");
-          flag.setEnabled(true);
-
-          return flag;
-        })
-        .build();
-
-    interceptor.addRule()
-        .get(baseUrl + "/flags/")
-        .respond(
-            "[]",
-            MEDIATYPE_JSON
-        );
-
-    Flags flags = client.getEnvironmentFlags();
-
-    DefaultFlag flag = (DefaultFlag) flags.getFlag("some_feature");
-    Assert.assertEquals(flag.getIsDefault(), Boolean.TRUE);
-    Assert.assertEquals(flag.getEnabled(), Boolean.TRUE);
-    Assert.assertEquals(flag.getValue(), "some-value");
-  }
-
-  @Test(groups = "unit")
-  public void testClient_When_Cache_Enabled_Return_Cache_Obj() {
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .setApiKey("api-key")
-        .withCache(FlagsmithCacheConfig
-            .newBuilder()
-            .enableEnvLevelCaching("newkey-random-name")
-            .maxSize(2)
-            .build())
-        .build();
-
-    FlagsmithCache cache = client.getCache();
-
-    Assert.assertNotNull(cache);
-  }
-
-  @Test(groups = "unit")
-  public void testGetIdentitySegmentsNoTraits() throws JsonProcessingException,
-      FlagsmithClientError {
-    String baseUrl = "http://bad-url";
-
-    EnvironmentModel environmentModel = FlagsmithTestHelper.environmentModel();
-
-    MockInterceptor interceptor = new MockInterceptor();
-    interceptor.addRule()
-        .get(baseUrl + "/environment-document/")
-        .anyTimes()
-        .respond(
-            MapperFactory.getMapper().writeValueAsString(environmentModel),
-            MEDIATYPE_JSON
-        );
-
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withConfiguration(
-            FlagsmithConfig.newBuilder()
-                .baseUri(baseUrl)
-                .addHttpInterceptor(interceptor)
-                .withLocalEvaluation(true)
-                .build()
-        ).setApiKey("ser.abcdefg")
-        .build();
-
-    client.updateEnvironment();
-
-    String identifier = "identifier";
-    List<Segment> segments = client.getIdentitySegments(identifier);
-
-    Assert.assertTrue(segments.isEmpty());
-  }
-
-
-  @Test(groups = "unit")
-  public void testGetIdentitySegmentsWithValidTrait() throws JsonProcessingException,
-      FlagsmithClientError {
-    String baseUrl = "http://bad-url";
-
-    EnvironmentModel environmentModel = FlagsmithTestHelper.environmentModel();
-
-    MockInterceptor interceptor = new MockInterceptor();
-    interceptor.addRule()
-        .get(baseUrl + "/environment-document/")
-        .anyTimes()
-        .respond(
-            MapperFactory.getMapper().writeValueAsString(environmentModel),
-            MEDIATYPE_JSON
-        );
-
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withConfiguration(
-            FlagsmithConfig.newBuilder()
-                .baseUri(baseUrl)
-                .addHttpInterceptor(interceptor)
-                .withLocalEvaluation(true)
-                .build()
-        ).setApiKey("ser.abcdefg")
-        .build();
-
-    client.updateEnvironment();
-
-    String identifier = "identifier";
-    Map<String, Object> traits = new HashMap<String, Object>(){{
-      put("foo", "bar");
-    }};
-
-    List<Segment> segments = client.getIdentitySegments(identifier, traits);
-
-    Assert.assertEquals(segments.size(), 1);
-    Assert.assertEquals(segments.get(0).getName(), "Test segment");
-  }
-
-  @Test(groups = "unit")
-  public void testUpdateEnvironment_DoesNothing_WhenGetEnvironmentThrowsExceptionAndEnvironmentExists() {
-    // Given
-    EnvironmentModel environmentModel = FlagsmithTestHelper.environmentModel();
-
-    FlagsmithApiWrapper mockApiWrapper = mock(FlagsmithApiWrapper.class);
-    when(mockApiWrapper.getEnvironment())
-            .thenReturn(environmentModel)
-            .thenThrow(RuntimeException.class);
-
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-            .withFlagsmithApiWrapper(mockApiWrapper)
-            .withConfiguration(FlagsmithConfig.newBuilder().withLocalEvaluation(true).build())
-            .setApiKey("ser.dummy-key")
-            .build();
-
-    // When
-    // we call the update environment method twice (1st should be successful, 2nd will do nothing because of error)
-    client.updateEnvironment();
-    client.updateEnvironment();
-
-    // Then
-    // No exception is thrown and the client environment remains what was first retrieved from the ApiWrapper
-    Assert.assertEquals(client.getEnvironment(), environmentModel);
-  }
-
-  @Test(groups = "unit")
-  public void testUpdateEnvironment_DoesNothing_WhenGetEnvironmentReturnsNullAndEnvironmentExists() {
-    // Given
-    EnvironmentModel environmentModel = FlagsmithTestHelper.environmentModel();
-
-    FlagsmithApiWrapper mockApiWrapper = mock(FlagsmithApiWrapper.class);
-    when(mockApiWrapper.getEnvironment())
-            .thenReturn(environmentModel)
-            .thenReturn(null);
-
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-            .withFlagsmithApiWrapper(mockApiWrapper)
-            .withConfiguration(FlagsmithConfig.newBuilder().withLocalEvaluation(true).build())
-            .setApiKey("ser.dummy-key")
-            .build();
-
-    // When
-    // we call the update environment method twice
-    // (1st should be successful, 2nd will do nothing because of null return)
-    client.updateEnvironment();
-    client.updateEnvironment();
-
-    // Then
-    // The client environment is not overwritten with null
-    Assert.assertEquals(client.getEnvironment(), environmentModel);
-  }
-
-  @Test(groups = "unit")
-  public void testUpdateEnvironment_DoesNothing_WhenGetEnvironmentReturnsNullAndEnvironmentNotExists() {
-    // Given
-    FlagsmithApiWrapper mockApiWrapper = mock(FlagsmithApiWrapper.class);
-    when(mockApiWrapper.getEnvironment()).thenThrow(RuntimeException.class);
-
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-            .withFlagsmithApiWrapper(mockApiWrapper)
-            .withConfiguration(FlagsmithConfig.newBuilder().withLocalEvaluation(true).build())
-            .setApiKey("ser.dummy-key")
-            .build();
-
-    // When
-    client.updateEnvironment();
-
-    // Then
-    // The environment remains null
-    Assert.assertEquals(client.getEnvironment(), null);
-  }
-
-  @Test(groups = "unit")
-  public void testClose_StopsPollingManager() {
-    // Given
-    PollingManager mockedPollingManager = mock(PollingManager.class);
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-            .withPollingManager(mockedPollingManager)
-            .withConfiguration(FlagsmithConfig.newBuilder().withLocalEvaluation(true).build())
-            .setApiKey("ser.dummy-key")
-            .build();
-
-    // When
-    client.close();
-
-    // Then
-    verify(mockedPollingManager, times(1)).stopPolling();
-  }
-
-  @Test(groups = "unit")
-  public void testClose_ClosesFlagsmithSdk() {
-    // Given
-    FlagsmithApiWrapper mockedApiWrapper = mock(FlagsmithApiWrapper.class);
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-            .withFlagsmithApiWrapper(mockedApiWrapper)
-            .withConfiguration(FlagsmithConfig.newBuilder().withLocalEvaluation(true).build())
-            .setApiKey("ser.dummy-key")
-            .build();
-
-    // When
-    client.close();
-
-    // Then
-    verify(mockedApiWrapper, times(1)).close();
-  }
-
-  @Test(groups = "unit")
-  public void testLocalEvaluation_ReturnsConsistentResults() throws FlagsmithClientError {
-    // Specific test to ensure that results are consistent when making multiple calls to
-    // evaluate flags soon after the client is instantiated.
-
-    // Given
-    EnvironmentModel environmentModel = FlagsmithTestHelper.environmentModel();
-
-    FlagsmithConfig config = FlagsmithConfig.newBuilder().withLocalEvaluation(true).build();
-
-    FlagsmithApiWrapper mockedApiWrapper = mock(FlagsmithApiWrapper.class);
-    when(mockedApiWrapper.getEnvironment())
-            .thenReturn(environmentModel)
-            .thenReturn(null);
-    when(mockedApiWrapper.getConfig()).thenReturn(config);
-
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-            .withFlagsmithApiWrapper(mockedApiWrapper)
-            .withConfiguration(config)
-            .setApiKey("ser.dummy-key")
-            .build();
-
-    // When
-    // make 3 calls to get identity flags
-    List<Flags> results = new ArrayList<>();
-    for (int i = 0; i < 3; ++i) {
-        results.add(client.getIdentityFlags("some-identity"));
+    private static String DEFAULT_FLAG_VALUE = "foobar";
+    private static boolean DEFAULT_FLAG_STATE = true;
+
+    private static BaseFlag defaultHandler(String featureName) {
+        DefaultFlag defaultFlag = new DefaultFlag();
+        defaultFlag.setEnabled(DEFAULT_FLAG_STATE);
+        defaultFlag.setValue(DEFAULT_FLAG_VALUE);
+        defaultFlag.setFeatureName(featureName);
+        return defaultFlag;
     }
 
-    // Then
-    // iterate over the results list and verify that the results are all the same
-    boolean expectedState = true;
-    String expectedValue = "some-value";
+    @Test(groups = "unit")
+    public void testClient_When_Cache_Disabled_Return_Null() {
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .setApiKey("api-key")
+                .build();
 
-    for (Flags flags : results) {
-        Assert.assertEquals(flags.isFeatureEnabled("some_feature"), expectedState);
-        Assert.assertEquals(flags.getFeatureValue("some_feature"), expectedValue);
+        FlagsmithCache cache = client.getCache();
+
+        Assert.assertNull(cache);
     }
-  }
 
-  @Test(groups = "unit")
-  public void testGetEnvironmentFlags_UsesDefaultFlags_IfLocalEvaluationEnvironmentNull() throws FlagsmithClientError {
-    // Given
-    FlagsmithConfig config = FlagsmithConfig.newBuilder().withLocalEvaluation(true).build();
-    FlagsmithApiWrapper mockedApiWrapper = mock(FlagsmithApiWrapper.class);
-    when(mockedApiWrapper.getEnvironment()).thenThrow(RuntimeException.class);
-    when(mockedApiWrapper.getConfig()).thenReturn(config);
+    @Test(groups = "unit")
+    public void testClient_validateObjectCreation() throws InterruptedException {
+        PollingManager manager = mock(PollingManager.class);
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withPollingManager(manager)
+                .withConfiguration(
+                        FlagsmithConfig.newBuilder().withLocalEvaluation(Boolean.TRUE).build())
+                .setApiKey("ser.abcdefg")
+                .build();
 
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withFlagsmithApiWrapper(mockedApiWrapper)
-        .withConfiguration(config)
-        .setApiKey("ser.dummy-key")
-        .setDefaultFlagValueFunction(FlagsmithClientTest::defaultHandler)
-        .build();
+        Thread.sleep(10);
+        verify(manager, times(1)).startPolling();
+    }
 
-    // When
-    Flags environmentFlags = client.getEnvironmentFlags();
+    @Test(groups = "unit")
+    public void testLocalEvaluationRequiresServerKey() throws InterruptedException {
+        Assert.assertThrows(RuntimeException.class, () -> FlagsmithClient.newBuilder()
+                .withConfiguration(
+                        FlagsmithConfig.newBuilder().withLocalEvaluation(Boolean.TRUE).build())
+                .setApiKey("not-a-server-key")
+                .build());
+    }
 
-    // Then
-    Assert.assertEquals(environmentFlags.getFeatureValue("foo"), DEFAULT_FLAG_VALUE);
-    Assert.assertEquals(environmentFlags.isFeatureEnabled("foo"), DEFAULT_FLAG_STATE);
-  }
+    @Test(groups = "unit")
+    public void testClient_errorEnvironmentApi() {
+        String baseUrl = "http://bad-url";
+        MockInterceptor interceptor = new MockInterceptor();
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withConfiguration(
+                        FlagsmithConfig.newBuilder()
+                                .baseUri(baseUrl)
+                                .addHttpInterceptor(interceptor)
+                                .build())
+                .setApiKey("api-key")
+                .build();
 
-  @Test(groups = "unit")
-  public void testGetIdentityFlags_UsesDefaultFlags_IfLocalEvaluationEnvironmentNull() throws FlagsmithClientError {
-    // Given
-    FlagsmithConfig config = FlagsmithConfig.newBuilder().withLocalEvaluation(true).build();
-    FlagsmithApiWrapper mockedApiWrapper = mock(FlagsmithApiWrapper.class);
-    when(mockedApiWrapper.getEnvironment()).thenThrow(RuntimeException.class);
-    when(mockedApiWrapper.getConfig()).thenReturn(config);
+        interceptor.addRule()
+                .get(baseUrl + "/environment-document/")
+                .respond(
+                        500,
+                        ResponseBody.create("error", MEDIATYPE_JSON));
 
-    FlagsmithClient client = FlagsmithClient.newBuilder()
-        .withFlagsmithApiWrapper(mockedApiWrapper)
-        .withConfiguration(config)
-        .setApiKey("ser.dummy-key")
-        .setDefaultFlagValueFunction(FlagsmithClientTest::defaultHandler)
-        .build();
+        Assert.assertThrows(Exception.class, () -> client.updateEnvironment());
+    }
 
-    // When
-    Flags identityFlags = client.getIdentityFlags("some-identity");
+    @Test(groups = "unit")
+    public void testClient_validateEnvironment()
+            throws JsonProcessingException {
+        String baseUrl = "http://bad-url";
+        MockInterceptor interceptor = new MockInterceptor();
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withConfiguration(
+                        FlagsmithConfig.newBuilder()
+                                .baseUri(baseUrl)
+                                .addHttpInterceptor(interceptor)
+                                .build())
+                .setApiKey("api-key")
+                .build();
 
-    // Then
-    Assert.assertEquals(identityFlags.getFeatureValue("foo"), DEFAULT_FLAG_VALUE);
-    Assert.assertEquals(identityFlags.isFeatureEnabled("foo"), DEFAULT_FLAG_STATE);
-  }
+        EnvironmentModel environmentModel = FlagsmithTestHelper.environmentModel();
+
+        interceptor.addRule()
+                .get(baseUrl + "/environment-document/")
+                .anyTimes()
+                .respond(
+                        MapperFactory.getMapper().writeValueAsString(environmentModel),
+                        MEDIATYPE_JSON);
+
+        client.updateEnvironment();
+        Assert.assertNotNull(client.getEnvironment());
+        Assert.assertEquals(client.getEnvironment(), environmentModel);
+    }
+
+    @Test(groups = "unit")
+    public void testClient_flagsApiException()
+            throws FlagsmithApiError {
+        String baseUrl = "http://bad-url";
+        MockInterceptor interceptor = new MockInterceptor();
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withConfiguration(
+                        FlagsmithConfig.newBuilder()
+                                .baseUri(baseUrl)
+                                .addHttpInterceptor(interceptor)
+                                .build())
+                .setApiKey("api-key")
+                .build();
+
+        interceptor.addRule()
+                .get(baseUrl + "/flags/")
+                .respond(
+                        500,
+                        ResponseBody.create("error", MEDIATYPE_JSON));
+
+        Assert.assertThrows(FlagsmithApiError.class, () -> client.getEnvironmentFlags());
+    }
+
+    @Test(groups = "unit")
+    public void testClient_flagsApiEmpty()
+            throws FlagsmithApiError {
+        String baseUrl = "http://bad-url";
+        MockInterceptor interceptor = new MockInterceptor();
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withConfiguration(
+                        FlagsmithConfig.newBuilder()
+                                .baseUri(baseUrl)
+                                .addHttpInterceptor(interceptor)
+                                .build())
+                .setApiKey("api-key")
+                .build();
+
+        interceptor.addRule()
+                .get(baseUrl + "/flags/")
+                .respond(
+                        "[]",
+                        MEDIATYPE_JSON);
+
+        Assert.assertNotNull(client);
+        List<BaseFlag> flags = client.getEnvironmentFlags().getAllFlags();
+        Assert.assertTrue(flags.isEmpty());
+    }
+
+    @Test(groups = "unit")
+    public void testClient_flagsApi()
+            throws JsonProcessingException, FlagsmithApiError {
+        String baseUrl = "http://bad-url";
+        MockInterceptor interceptor = new MockInterceptor();
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withConfiguration(
+                        FlagsmithConfig.newBuilder()
+                                .baseUri(baseUrl)
+                                .addHttpInterceptor(interceptor)
+                                .build())
+                .setApiKey("api-key")
+                .build();
+
+        List<FeatureStateModel> featureStateModel = FlagsmithTestHelper.getFlags();
+
+        interceptor.addRule()
+                .get(baseUrl + "/flags/")
+                .respond(
+                        MapperFactory.getMapper().writeValueAsString(featureStateModel),
+                        MEDIATYPE_JSON);
+
+        List<BaseFlag> flags = client.getEnvironmentFlags().getAllFlags();
+        Assert.assertEquals(flags.get(0).getEnabled(), Boolean.TRUE);
+        Assert.assertEquals(flags.get(0).getValue(), "some-value");
+        Assert.assertEquals(flags.get(0).getFeatureName(), "some_feature");
+    }
+
+    @Test(groups = "unit")
+    public void testClient_identityFlagsApiNoTraitsException() throws FlagsmithClientError {
+        String baseUrl = "http://bad-url";
+        String identifier = "identifier";
+        MockInterceptor interceptor = new MockInterceptor();
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withConfiguration(
+                        FlagsmithConfig.newBuilder()
+                                .baseUri(baseUrl)
+                                .addHttpInterceptor(interceptor)
+                                .build())
+                .setApiKey("api-key")
+                .build();
+
+        interceptor.addRule()
+                .post(baseUrl + "/identities/")
+                .respond(
+                        500,
+                        ResponseBody.create("error", MEDIATYPE_JSON));
+
+        Assert.assertThrows(FlagsmithApiError.class, () -> client.getIdentityFlags(identifier));
+    }
+
+    @Test(groups = "unit")
+    public void testClient_identityFlagsApiNoTraits() throws FlagsmithClientError {
+        String baseUrl = "http://bad-url";
+        String identifier = "identifier";
+        MockInterceptor interceptor = new MockInterceptor();
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withConfiguration(
+                        FlagsmithConfig.newBuilder()
+                                .baseUri(baseUrl)
+                                .addHttpInterceptor(interceptor)
+                                .build())
+                .setApiKey("api-key")
+                .build();
+
+        String json = FlagsmithTestHelper.getIdentitiesFlags();
+
+        interceptor.addRule()
+                .post(baseUrl + "/identities/")
+                .respond(
+                        json,
+                        MEDIATYPE_JSON);
+
+        List<BaseFlag> flags = client.getIdentityFlags(identifier).getAllFlags();
+        Assert.assertEquals(flags.get(0).getEnabled(), Boolean.TRUE);
+        Assert.assertEquals(flags.get(0).getValue(), "some-value");
+        Assert.assertEquals(flags.get(0).getFeatureName(), "some_feature");
+    }
+
+    @Test(groups = "unit")
+    public void testClient_identityFlagsApiWithTraits()
+            throws FlagsmithClientError, IOException {
+        String baseUrl = "http://bad-url";
+        String identifier = "identifier";
+        Map<String, Object> traits = new HashMap<String, Object>() {
+            {
+                put("some_trait", "some_value");
+            }
+        };
+        MockInterceptor interceptor = new MockInterceptor();
+        RequestProcessor requestProcessor = mock(RequestProcessor.class);
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withConfiguration(
+                        FlagsmithConfig.newBuilder()
+                                .baseUri(baseUrl)
+                                .addHttpInterceptor(interceptor)
+                                .build())
+                .setApiKey("api-key")
+                .build();
+        // mocking the requestor
+        ((FlagsmithApiWrapper) client.getFlagsmithSdk()).setRequestor(requestProcessor);
+        String json = FlagsmithTestHelper.getIdentitiesFlags();
+        TypeReference<FlagsAndTraitsResponse> tr = new TypeReference<FlagsAndTraitsResponse>() {
+        };
+
+        when(requestProcessor.executeAsync(any(), any(), any()))
+                .thenReturn(
+                        FlagsmithTestHelper.futurableReturn(MapperFactory.getMapper().readValue(json, tr)));
+
+        List<BaseFlag> flags = client.getIdentityFlags(identifier, traits).getAllFlags();
+
+        ArgumentCaptor<Request> argument = ArgumentCaptor.forClass(Request.class);
+        verify(requestProcessor, times(1)).executeAsync(argument.capture(), any(), any());
+
+        Buffer buffer = new Buffer();
+        argument.getValue().body().writeTo(buffer);
+
+        JsonNode expectedRequest = FlagsmithTestHelper.getIdentityRequest(identifier, new ArrayList<TraitModel>() {
+            {
+                add(new TraitModel("some_trait", "some_value"));
+            }
+        });
+
+        Assert.assertEquals(expectedRequest.toString(), buffer.readUtf8());
+        Assert.assertEquals(flags.get(0).getEnabled(), Boolean.TRUE);
+        Assert.assertEquals(flags.get(0).getValue(), "some-value");
+        Assert.assertEquals(flags.get(0).getFeatureName(), "some_feature");
+    }
+
+    @Test(groups = "unit")
+    public void testClient_identityFlagsApiWithTraitsWithLocalEnvironment() {
+        String baseUrl = "http://bad-url";
+        String identifier = "identifier";
+        Map<String, Object> traits = new HashMap<String, Object>() {
+            {
+                put("some_trait", "some_value");
+            }
+        };
+        MockInterceptor interceptor = new MockInterceptor();
+        RequestProcessor requestProcessor = mock(RequestProcessor.class);
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withConfiguration(
+                        FlagsmithConfig.newBuilder()
+                                .baseUri(baseUrl)
+                                .addHttpInterceptor(interceptor)
+                                .build())
+                .setApiKey("api-key")
+                .build();
+
+        interceptor.addRule()
+                .get(baseUrl + "/flags/").anyTimes()
+                .respond(500, ResponseBody.create("error", MEDIATYPE_JSON));
+
+        assertThrows(FlagsmithApiError.class,
+                () -> client.getEnvironmentFlags());
+    }
+
+    @Test(groups = "unit")
+    public void testClient_defaultFlagWithNoEnvironment() throws FlagsmithClientError {
+        String baseUrl = "http://bad-url";
+        String identifier = "identifier";
+        Map<String, Object> traits = new HashMap<String, Object>() {
+            {
+                put("some_trait", "some_value");
+            }
+        };
+        MockInterceptor interceptor = new MockInterceptor();
+        RequestProcessor requestProcessor = mock(RequestProcessor.class);
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withConfiguration(
+                        FlagsmithConfig.newBuilder()
+                                .baseUri(baseUrl)
+                                .addHttpInterceptor(interceptor)
+                                .build())
+                .setApiKey("api-key")
+                .setDefaultFlagValueFunction((name) -> {
+                    DefaultFlag flag = new DefaultFlag();
+                    flag.setValue("some-value");
+                    flag.setEnabled(true);
+
+                    return flag;
+                })
+                .build();
+
+        interceptor.addRule()
+                .get(baseUrl + "/flags/")
+                .respond(
+                        "[]",
+                        MEDIATYPE_JSON);
+
+        Flags flags = client.getEnvironmentFlags();
+
+        DefaultFlag flag = (DefaultFlag) flags.getFlag("some_feature");
+        Assert.assertEquals(flag.getIsDefault(), Boolean.TRUE);
+        Assert.assertEquals(flag.getEnabled(), Boolean.TRUE);
+        Assert.assertEquals(flag.getValue(), "some-value");
+    }
+
+    @Test(groups = "unit")
+    public void testClient_When_Cache_Enabled_Return_Cache_Obj() {
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .setApiKey("api-key")
+                .withCache(FlagsmithCacheConfig
+                        .newBuilder()
+                        .enableEnvLevelCaching("newkey-random-name")
+                        .maxSize(2)
+                        .build())
+                .build();
+
+        FlagsmithCache cache = client.getCache();
+
+        Assert.assertNotNull(cache);
+    }
+
+    @Test(groups = "unit")
+    public void testGetIdentitySegmentsNoTraits() throws JsonProcessingException,
+            FlagsmithClientError {
+        String baseUrl = "http://bad-url";
+
+        EnvironmentModel environmentModel = FlagsmithTestHelper.environmentModel();
+
+        MockInterceptor interceptor = new MockInterceptor();
+        interceptor.addRule()
+                .get(baseUrl + "/environment-document/")
+                .anyTimes()
+                .respond(
+                        MapperFactory.getMapper().writeValueAsString(environmentModel),
+                        MEDIATYPE_JSON);
+
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withConfiguration(
+                        FlagsmithConfig.newBuilder()
+                                .baseUri(baseUrl)
+                                .addHttpInterceptor(interceptor)
+                                .withLocalEvaluation(true)
+                                .build())
+                .setApiKey("ser.abcdefg")
+                .build();
+
+        client.updateEnvironment();
+
+        String identifier = "identifier";
+        List<Segment> segments = client.getIdentitySegments(identifier);
+
+        Assert.assertTrue(segments.isEmpty());
+    }
+
+    @Test(groups = "unit")
+    public void testGetIdentitySegmentsWithValidTrait() throws JsonProcessingException,
+            FlagsmithClientError {
+        String baseUrl = "http://bad-url";
+
+        EnvironmentModel environmentModel = FlagsmithTestHelper.environmentModel();
+
+        MockInterceptor interceptor = new MockInterceptor();
+        interceptor.addRule()
+                .get(baseUrl + "/environment-document/")
+                .anyTimes()
+                .respond(
+                        MapperFactory.getMapper().writeValueAsString(environmentModel),
+                        MEDIATYPE_JSON);
+
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withConfiguration(
+                        FlagsmithConfig.newBuilder()
+                                .baseUri(baseUrl)
+                                .addHttpInterceptor(interceptor)
+                                .withLocalEvaluation(true)
+                                .build())
+                .setApiKey("ser.abcdefg")
+                .build();
+
+        client.updateEnvironment();
+
+        String identifier = "identifier";
+        Map<String, Object> traits = new HashMap<String, Object>() {
+            {
+                put("foo", "bar");
+            }
+        };
+
+        List<Segment> segments = client.getIdentitySegments(identifier, traits);
+
+        Assert.assertEquals(segments.size(), 1);
+        Assert.assertEquals(segments.get(0).getName(), "Test segment");
+    }
+
+    @Test(groups = "unit")
+    public void testUpdateEnvironment_DoesNothing_WhenGetEnvironmentThrowsExceptionAndEnvironmentExists() {
+        // Given
+        EnvironmentModel environmentModel = FlagsmithTestHelper.environmentModel();
+
+        FlagsmithApiWrapper mockApiWrapper = mock(FlagsmithApiWrapper.class);
+        when(mockApiWrapper.getEnvironment())
+                .thenReturn(environmentModel)
+                .thenThrow(RuntimeException.class);
+
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withFlagsmithApiWrapper(mockApiWrapper)
+                .withConfiguration(FlagsmithConfig.newBuilder().withLocalEvaluation(true).build())
+                .setApiKey("ser.dummy-key")
+                .build();
+
+        // When
+        // we call the update environment method twice (1st should be successful, 2nd
+        // will do nothing because of error)
+        client.updateEnvironment();
+        client.updateEnvironment();
+
+        // Then
+        // No exception is thrown and the client environment remains what was first
+        // retrieved from the ApiWrapper
+        Assert.assertEquals(client.getEnvironment(), environmentModel);
+    }
+
+    @Test(groups = "unit")
+    public void testUpdateEnvironment_DoesNothing_WhenGetEnvironmentReturnsNullAndEnvironmentExists() {
+        // Given
+        EnvironmentModel environmentModel = FlagsmithTestHelper.environmentModel();
+
+        FlagsmithApiWrapper mockApiWrapper = mock(FlagsmithApiWrapper.class);
+        when(mockApiWrapper.getEnvironment())
+                .thenReturn(environmentModel)
+                .thenReturn(null);
+
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withFlagsmithApiWrapper(mockApiWrapper)
+                .withConfiguration(FlagsmithConfig.newBuilder().withLocalEvaluation(true).build())
+                .setApiKey("ser.dummy-key")
+                .build();
+
+        // When
+        // we call the update environment method twice
+        // (1st should be successful, 2nd will do nothing because of null return)
+        client.updateEnvironment();
+        client.updateEnvironment();
+
+        // Then
+        // The client environment is not overwritten with null
+        Assert.assertEquals(client.getEnvironment(), environmentModel);
+    }
+
+    @Test(groups = "unit")
+    public void testUpdateEnvironment_DoesNothing_WhenGetEnvironmentReturnsNullAndEnvironmentNotExists() {
+        // Given
+        FlagsmithApiWrapper mockApiWrapper = mock(FlagsmithApiWrapper.class);
+        when(mockApiWrapper.getEnvironment()).thenThrow(RuntimeException.class);
+
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withFlagsmithApiWrapper(mockApiWrapper)
+                .withConfiguration(FlagsmithConfig.newBuilder().withLocalEvaluation(true).build())
+                .setApiKey("ser.dummy-key")
+                .build();
+
+        // When
+        client.updateEnvironment();
+
+        // Then
+        // The environment remains null
+        Assert.assertEquals(client.getEnvironment(), null);
+    }
+
+    @Test(groups = "unit")
+    public void testClose_StopsPollingManager() {
+        // Given
+        PollingManager mockedPollingManager = mock(PollingManager.class);
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withPollingManager(mockedPollingManager)
+                .withConfiguration(FlagsmithConfig.newBuilder().withLocalEvaluation(true).build())
+                .setApiKey("ser.dummy-key")
+                .build();
+
+        // When
+        client.close();
+
+        // Then
+        verify(mockedPollingManager, times(1)).stopPolling();
+    }
+
+    @Test(groups = "unit")
+    public void testClose_ClosesFlagsmithSdk() {
+        // Given
+        FlagsmithApiWrapper mockedApiWrapper = mock(FlagsmithApiWrapper.class);
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withFlagsmithApiWrapper(mockedApiWrapper)
+                .withConfiguration(FlagsmithConfig.newBuilder().withLocalEvaluation(true).build())
+                .setApiKey("ser.dummy-key")
+                .build();
+
+        // When
+        client.close();
+
+        // Then
+        verify(mockedApiWrapper, times(1)).close();
+    }
+
+    @Test(groups = "unit")
+    public void testLocalEvaluation_ReturnsConsistentResults() throws FlagsmithClientError {
+        // Specific test to ensure that results are consistent when making multiple
+        // calls to
+        // evaluate flags soon after the client is instantiated.
+
+        // Given
+        EnvironmentModel environmentModel = FlagsmithTestHelper.environmentModel();
+
+        FlagsmithConfig config = FlagsmithConfig.newBuilder().withLocalEvaluation(true).build();
+
+        FlagsmithApiWrapper mockedApiWrapper = mock(FlagsmithApiWrapper.class);
+        when(mockedApiWrapper.getEnvironment())
+                .thenReturn(environmentModel)
+                .thenReturn(null);
+        when(mockedApiWrapper.getConfig()).thenReturn(config);
+
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withFlagsmithApiWrapper(mockedApiWrapper)
+                .withConfiguration(config)
+                .setApiKey("ser.dummy-key")
+                .build();
+
+        // When
+        // make 3 calls to get identity flags
+        List<Flags> results = new ArrayList<>();
+        for (int i = 0; i < 3; ++i) {
+            results.add(client.getIdentityFlags("some-identity"));
+        }
+
+        // Then
+        // iterate over the results list and verify that the results are all the same
+        boolean expectedState = true;
+        String expectedValue = "some-value";
+
+        for (Flags flags : results) {
+            Assert.assertEquals(flags.isFeatureEnabled("some_feature"), expectedState);
+            Assert.assertEquals(flags.getFeatureValue("some_feature"), expectedValue);
+        }
+    }
+
+    @Test(groups = "unit")
+    public void testGetEnvironmentFlags_UsesDefaultFlags_IfLocalEvaluationEnvironmentNull()
+            throws FlagsmithClientError {
+        // Given
+        FlagsmithConfig config = FlagsmithConfig.newBuilder().withLocalEvaluation(true).build();
+        FlagsmithApiWrapper mockedApiWrapper = mock(FlagsmithApiWrapper.class);
+        when(mockedApiWrapper.getEnvironment()).thenThrow(RuntimeException.class);
+        when(mockedApiWrapper.getConfig()).thenReturn(config);
+
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withFlagsmithApiWrapper(mockedApiWrapper)
+                .withConfiguration(config)
+                .setApiKey("ser.dummy-key")
+                .setDefaultFlagValueFunction(FlagsmithClientTest::defaultHandler)
+                .build();
+
+        // When
+        Flags environmentFlags = client.getEnvironmentFlags();
+
+        // Then
+        Assert.assertEquals(environmentFlags.getFeatureValue("foo"), DEFAULT_FLAG_VALUE);
+        Assert.assertEquals(environmentFlags.isFeatureEnabled("foo"), DEFAULT_FLAG_STATE);
+    }
+
+    @Test(groups = "unit")
+    public void testGetIdentityFlags_UsesDefaultFlags_IfLocalEvaluationEnvironmentNull() throws FlagsmithClientError {
+        // Given
+        FlagsmithConfig config = FlagsmithConfig.newBuilder().withLocalEvaluation(true).build();
+        FlagsmithApiWrapper mockedApiWrapper = mock(FlagsmithApiWrapper.class);
+        when(mockedApiWrapper.getEnvironment()).thenThrow(RuntimeException.class);
+        when(mockedApiWrapper.getConfig()).thenReturn(config);
+
+        FlagsmithClient client = FlagsmithClient.newBuilder()
+                .withFlagsmithApiWrapper(mockedApiWrapper)
+                .withConfiguration(config)
+                .setApiKey("ser.dummy-key")
+                .setDefaultFlagValueFunction(FlagsmithClientTest::defaultHandler)
+                .build();
+
+        // When
+        Flags identityFlags = client.getIdentityFlags("some-identity");
+
+        // Then
+        Assert.assertEquals(identityFlags.getFeatureValue("foo"), DEFAULT_FLAG_VALUE);
+        Assert.assertEquals(identityFlags.isFeatureEnabled("foo"), DEFAULT_FLAG_STATE);
+    }
 }

--- a/src/test/java/com/flagsmith/FlagsmithClientTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithClientTest.java
@@ -164,7 +164,7 @@ public class FlagsmithClientTest {
 
     @Test(groups = "unit")
     public void testClient_flagsApiEmpty()
-            throws FlagsmithApiError {
+            throws FlagsmithClientError {
         String baseUrl = "http://bad-url";
         MockInterceptor interceptor = new MockInterceptor();
         FlagsmithClient client = FlagsmithClient.newBuilder()
@@ -189,7 +189,7 @@ public class FlagsmithClientTest {
 
     @Test(groups = "unit")
     public void testClient_flagsApi()
-            throws JsonProcessingException, FlagsmithApiError {
+            throws JsonProcessingException, FlagsmithClientError {
         String baseUrl = "http://bad-url";
         MockInterceptor interceptor = new MockInterceptor();
         FlagsmithClient client = FlagsmithClient.newBuilder()


### PR DESCRIPTION
This PR achieves 2 things: 

 1. Prevents the client from throwing an exception on startup if it's unable to retrieve the environment information 
 2. Uses default flags when in local evaluation mode but the environment is not present