### PR TITLE
Fix tests expecting the wrong exception

### DIFF
--- a/src/main/java/com/flagsmith/config/FlagsmithCacheConfig.java
+++ b/src/main/java/com/flagsmith/config/FlagsmithCacheConfig.java
@@ -144,8 +144,8 @@ public final class FlagsmithCacheConfig {
      * @param envFlagsCacheKey key to use in the cache for environment level flags
      * @return the Builder
      */
-    public Builder enableEnvLevelCaching(@NonNull String envFlagsCacheKey) {
-      if (StringUtils.isBlank(envFlagsCacheKey)) {
+    public Builder enableEnvLevelCaching(String envFlagsCacheKey) {
+      if (envFlagsCacheKey == null || StringUtils.isBlank(envFlagsCacheKey)) {
         throw new IllegalArgumentException("Missing environment level cache key");
       }
       this.envFlagsCacheKey = envFlagsCacheKey;

--- a/src/main/java/com/flagsmith/interfaces/FlagsmithSdk.java
+++ b/src/main/java/com/flagsmith/interfaces/FlagsmithSdk.java
@@ -23,7 +23,7 @@ public interface FlagsmithSdk {
   );
 
   FlagsmithConfig getConfig();
-  
+
   EnvironmentModel getEnvironment();
 
   RequestProcessor getRequestor();
@@ -43,8 +43,8 @@ public interface FlagsmithSdk {
    * validate user has a valid identifier.
    * @param identifier user identifier
    */
-  default void assertValidUser(@NonNull String identifier) {
-    if (StringUtils.isBlank(identifier)) {
+  default void assertValidUser(String identifier) {
+    if (identifier == null || StringUtils.isBlank(identifier)) {
       throw new IllegalArgumentException("Missing user identifier");
     }
   }


### PR DESCRIPTION
I'm not entirely sure how these tests are passing in the Github workflows. I can't get them to pass locally at all. The `NotNull` decorator, however, specifies that it will raise a NullPointerException so the tests are just wrong. That being said, I think the user experience from raising the IllegalArgumentException is slightly nicer. 

I guess the question (as per my other PR) is whether this constitutes a major version since we're changing the exception being raised? 