### PR TITLE
Prevent duplicate environment updates on polling manager start

### DIFF
--- a/src/main/java/com/flagsmith/threads/PollingManager.java
+++ b/src/main/java/com/flagsmith/threads/PollingManager.java
@@ -37,8 +37,8 @@ public class PollingManager {
       public void run() {
         try {
           while (!this.isInterrupted()) {
-            client.updateEnvironment();
             Thread.sleep(interval);
+            client.updateEnvironment();
           }
         } catch (InterruptedException e) {
           logger.info("Polling manager interrupted. Automatic environment update will stop!");

--- a/src/test/java/com/flagsmith/threads/PollingManagerTest.java
+++ b/src/test/java/com/flagsmith/threads/PollingManagerTest.java
@@ -21,17 +21,17 @@ public class PollingManagerTest {
     manager.startPolling();
   }
 
+  @Test(groups = "unit")
   public void testPollingManager_checkPollingMethodInvoked() throws InterruptedException {
     verify(client, times(1)).updateEnvironment();
-    Thread.sleep(50);
-    verify(client, times(2)).updateEnvironment();
     Thread.sleep(1500);
-    verify(client, times(3)).updateEnvironment();
+    verify(client, times(2)).updateEnvironment();
   }
 
+  @Test(groups = "unit")
   public void testPollingManager_checkPollingMethodInvokedAndStopped() throws InterruptedException {
     verify(client, times(1)).updateEnvironment();
-    Thread.sleep(50);
+    Thread.sleep(1500);
     verify(client, times(2)).updateEnvironment();
     manager.stopPolling();
     Thread.sleep(1500);


### PR DESCRIPTION
Ensures that the environment is only updated once on Polling Manager start up by sleeping first, then updating. This should fix the flaky tests that we've seen and will obviously also reduce the number of API calls that clients need to make. 