### PR TITLE
Ensure that identity caches are separate

### DIFF
--- a/src/main/java/com/flagsmith/FlagsmithApiWrapper.java
+++ b/src/main/java/com/flagsmith/FlagsmithApiWrapper.java
@@ -174,9 +174,11 @@ public class FlagsmithApiWrapper implements FlagsmithSdk {
   ) {
     assertValidUser(identifier);
     Flags flags = null;
+    String cacheKey = null;
 
-    if (getCache() != null && getCache().getEnvFlagsCacheKey() != null) {
-      flags = getCache().getIfPresent(getCache().getEnvFlagsCacheKey());
+    if (getCache() != null) {
+      cacheKey = getCache().getIdentityFlagsCacheKey(identifier);
+      flags = getCache().getIfPresent(cacheKey);
 
       if (flags != null) {
         return flags;
@@ -218,9 +220,9 @@ public class FlagsmithApiWrapper implements FlagsmithSdk {
           getConfig().getFlagsmithFlagDefaults()
       );
 
-      if (getCache() != null) {
-        getCache().getCache().put("identifier" + identifier, flags);
-        logger.info("Got feature flags for flags = {} and cached.", flags);
+      if (cacheKey != null) {
+        getCache().getCache().put(cacheKey, flags);
+        logger.info("Cached flags for identity {}.", identifier);
       }
 
     } catch (TimeoutException ie) {

--- a/src/main/java/com/flagsmith/config/FlagsmithCacheConfig.java
+++ b/src/main/java/com/flagsmith/config/FlagsmithCacheConfig.java
@@ -207,6 +207,11 @@ public final class FlagsmithCacheConfig {
     }
 
     @Override
+    public String getIdentityFlagsCacheKey(String identifier) {
+      return "identity" + identifier;
+    }
+
+    @Override
     public Cache<String, Flags> getCache() {
       return cache;
     }

--- a/src/main/java/com/flagsmith/interfaces/FlagsmithCache.java
+++ b/src/main/java/com/flagsmith/interfaces/FlagsmithCache.java
@@ -70,6 +70,13 @@ public interface FlagsmithCache {
   String getEnvFlagsCacheKey();
 
   /**
+   * Returns the cache key for a given identity.
+   *
+   * @return string
+   */
+  String getIdentityFlagsCacheKey(String identifier);
+
+  /**
    * Returns the Cache instance.
    *
    * @return

--- a/src/test/java/com/flagsmith/FlagsmithApiWrapperCachingTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithApiWrapperCachingTest.java
@@ -156,7 +156,10 @@ public class FlagsmithApiWrapperCachingTest {
   public void identifyUserWithTraits_fetchFlagsFromFlagsmithAndStoreThemInCache_whenCacheEmpty() {
     // Arrange
     String identifier = "test-user";
+    String expectedCacheKey = "identity" + identifier;
     final ArrayList<TraitModel> traits = new ArrayList<>();
+
+    when(flagsmithCacheImpl.getIdentityFlagsCacheKey(identifier)).thenReturn(expectedCacheKey);
 
     final FlagsAndTraitsResponse flagsAndTraitsResponse = new FlagsAndTraitsResponse();
     when(requestProcessor.executeAsync(any(), any(), any()))
@@ -170,6 +173,11 @@ public class FlagsmithApiWrapperCachingTest {
     // Assert
     verify(requestProcessor, times(1)).executeAsync(any(), any(), any());
     assertEquals(newFlagsList(new ArrayList<>()), actualUserFlagsAndTraits);
+
+    verify(flagsmithCacheImpl, times(1)).getIfPresent(expectedCacheKey);
+
+    assertEquals(1, cache.estimatedSize());
+    assertEquals(cache.getIfPresent(expectedCacheKey), actualUserFlagsAndTraits);
   }
 
   @Test


### PR DESCRIPTION
Identity caches were using the environment cache key meaning that, if a request was made to retrieve the flags for an environment before one to retrieve the flags for an identity, the identity would receive the cached environment flags. 

The identity's flags were weirdly being written to the cache with their own cache key, but were being retrieved using the environment cache key. 