### PR TITLE
fix: FlagsmithClient.close() doesn't kill polling manager properly

### DIFF
--- a/src/main/java/com/flagsmith/threads/PollingManager.java
+++ b/src/main/java/com/flagsmith/threads/PollingManager.java
@@ -32,7 +32,7 @@ public class PollingManager {
    * @return
    */
   private Thread initializeThread() {
-    return new Thread() {
+    Thread thread = new Thread() {
       @Override
       public void run() {
         try {
@@ -45,6 +45,8 @@ public class PollingManager {
         }
       }
     };
+    thread.setDaemon(true);
+    return thread;
   }
 
   /**
@@ -61,5 +63,10 @@ public class PollingManager {
     internalThread.interrupt();
   }
 
-
+  /**
+   * Get thread status
+   */
+  public Boolean getIsThreadAlive() {
+    return internalThread.isAlive();
+  }
 }

--- a/src/test/java/com/flagsmith/FlagsmithClientTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithClientTest.java
@@ -717,7 +717,6 @@ public class FlagsmithClientTest {
                 .build();
 
         // When
-        client.getEnvironmentFlags();
         client.close();
 
         // Then

--- a/src/test/java/com/flagsmith/FlagsmithClientTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithClientTest.java
@@ -721,7 +721,7 @@ public class FlagsmithClientTest {
 
         // Then
         // Since the thread will only stop once it reads the interrupt signal correctly
-        // on it's next polling interval, we need to wait for the polling interval
+        // on its next polling interval, we need to wait for the polling interval
         // to complete before checking the thread has been killed correctly.
         Thread.sleep(pollingInterval);
         assertFalse(client.getPollingManager().getIsThreadAlive());

--- a/src/test/java/com/flagsmith/FlagsmithClientTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithClientTest.java
@@ -720,6 +720,9 @@ public class FlagsmithClientTest {
         client.close();
 
         // Then
+        // Since the thread will only stop once it reads the interrupt signal correctly
+        // on it's next polling interval, we need to wait for the polling interval
+        // to complete before checking the thread has been killed correctly.
         Thread.sleep(pollingInterval);
         assertFalse(client.getPollingManager().getIsThreadAlive());
     }


### PR DESCRIPTION
Resolves an issue identified in the client where the polling manager thread is not killed correctly on `FlagsmithClient.close()`. 

This PR changes the polling manager thread to a daemon thread and ensures that it is killed correctly on `close()`. 

I have added a test to verify that this behaviour works as expected. 