### PR TITLE
feat: Identity overrides in local evaluation mode

### DIFF
--- a/src/main/java/com/flagsmith/FlagsmithClient.java
+++ b/src/main/java/com/flagsmith/FlagsmithClient.java
@@ -39,7 +39,7 @@ public class FlagsmithClient {
   private FlagsmithSdk flagsmithSdk;
   private EnvironmentModel environment;
   private PollingManager pollingManager;
-  private Map<String, IdentityModel> identityOverridesByIdentifier;
+  private Map<String, IdentityModel> identitiesWithOverridesByIdentifier;
 
   private FlagsmithClient() {
   }
@@ -61,11 +61,11 @@ public class FlagsmithClient {
         List<IdentityModel> identityOverrides = updatedEnvironment.getIdentityOverrides();
 
         if (identityOverrides != null) {
-          Map<String, IdentityModel> identityOverridesByIdentifier = new HashMap<>();
+          Map<String, IdentityModel> identitiesWithOverridesByIdentifier = new HashMap<>();
           for (IdentityModel identity : identityOverrides) {
-            identityOverridesByIdentifier.put(identity.getIdentifier(), identity);
+            identitiesWithOverridesByIdentifier.put(identity.getIdentifier(), identity);
           }
-          this.identityOverridesByIdentifier = identityOverridesByIdentifier;
+          this.identitiesWithOverridesByIdentifier = identitiesWithOverridesByIdentifier;
         }
 
         this.environment = updatedEnvironment;
@@ -271,8 +271,8 @@ public class FlagsmithClient {
       return trait;
     }).collect(Collectors.toList());
 
-    if (identityOverridesByIdentifier != null) {
-      IdentityModel identityOverride = identityOverridesByIdentifier.get(identifier);
+    if (identitiesWithOverridesByIdentifier != null) {
+      IdentityModel identityOverride = identitiesWithOverridesByIdentifier.get(identifier);
       if (identityOverride != null) {
         identityOverride.updateTraits(traitsList);
         return identityOverride;

--- a/src/main/java/com/flagsmith/FlagsmithClient.java
+++ b/src/main/java/com/flagsmith/FlagsmithClient.java
@@ -39,6 +39,7 @@ public class FlagsmithClient {
   private FlagsmithSdk flagsmithSdk;
   private EnvironmentModel environment;
   private PollingManager pollingManager;
+  private Map<String, IdentityModel> identityOverridesByIdentifier;
 
   private FlagsmithClient() {
   }
@@ -57,6 +58,16 @@ public class FlagsmithClient {
       // if we didn't get an environment from the API,
       // then don't overwrite the copy we already have.
       if (updatedEnvironment != null) {
+        List<IdentityModel> identityOverrides = updatedEnvironment.getIdentityOverrides();
+
+        if (identityOverrides != null) {
+          Map<String, IdentityModel> identityOverridesByIdentifier = new HashMap<>();
+          for (IdentityModel identity : identityOverrides) {
+            identityOverridesByIdentifier.put(identity.getIdentifier(), identity);
+          }
+          this.identityOverridesByIdentifier = identityOverridesByIdentifier;
+        }
+
         this.environment = updatedEnvironment;
       } else {
         logger.error(getEnvironmentUpdateErrorMessage());
@@ -138,7 +149,7 @@ public class FlagsmithClient {
     if (environment == null) {
       throw new FlagsmithClientError("Local evaluation required to obtain identity segments.");
     }
-    IdentityModel identityModel = buildIdentityModel(
+    IdentityModel identityModel = getIdentityModel(
         identifier, (traits != null ? traits : new HashMap<>()));
     List<SegmentModel> segmentModels = SegmentEvaluator.getIdentitySegments(
         environment, identityModel);
@@ -187,7 +198,7 @@ public class FlagsmithClient {
       return getDefaultFlags();
     }
 
-    IdentityModel identity = buildIdentityModel(identifier, traits);
+    IdentityModel identity = getIdentityModel(identifier, traits);
     List<FeatureStateModel> featureStates = Engine.getIdentityFeatureStates(environment, identity);
 
     return Flags.fromFeatureStateModels(
@@ -233,11 +244,11 @@ public class FlagsmithClient {
     }
   }
 
-  private IdentityModel buildIdentityModel(String identifier, Map<String, Object> traits)
+  private IdentityModel getIdentityModel(String identifier, Map<String, Object> traits)
       throws FlagsmithClientError {
     if (environment == null) {
       throw new FlagsmithClientError(
-        "Unable to build identity model when no local environment present.");
+          "Unable to build identity model when no local environment present.");
     }
 
     List<TraitModel> traitsList = traits.entrySet().stream().map((entry) -> {
@@ -247,6 +258,14 @@ public class FlagsmithClient {
 
       return trait;
     }).collect(Collectors.toList());
+
+    if (identityOverridesByIdentifier != null) {
+      IdentityModel identityOverride = identityOverridesByIdentifier.get(identifier);
+      if (identityOverride != null) {
+        identityOverride.updateTraits(traitsList);
+        return identityOverride;
+      }
+    }
 
     IdentityModel identity = new IdentityModel();
     identity.setIdentityTraits(traitsList);
@@ -265,7 +284,7 @@ public class FlagsmithClient {
   private String getEnvironmentUpdateErrorMessage() {
     if (this.environment == null) {
       return "Unable to update environment from API. "
-             + "No environment configured - using defaultHandler if configured.";
+          + "No environment configured - using defaultHandler if configured.";
     } else {
       return "Unable to update environment from API. Continuing to use previous copy.";
     }

--- a/src/main/java/com/flagsmith/flagengine/environments/EnvironmentModel.java
+++ b/src/main/java/com/flagsmith/flagengine/environments/EnvironmentModel.java
@@ -1,13 +1,12 @@
 package com.flagsmith.flagengine.environments;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.flagsmith.flagengine.environments.integrations.IntegrationModel;
 import com.flagsmith.flagengine.features.FeatureStateModel;
+import com.flagsmith.flagengine.identities.IdentityModel;
 import com.flagsmith.flagengine.projects.ProjectModel;
 import com.flagsmith.utils.models.BaseModel;
 import java.util.List;
 import lombok.Data;
-
 
 @Data
 public class EnvironmentModel extends BaseModel {
@@ -20,12 +19,6 @@ public class EnvironmentModel extends BaseModel {
   @JsonProperty("feature_states")
   private List<FeatureStateModel> featureStates;
 
-  @JsonProperty("amplitude_config")
-  private IntegrationModel amplitudeConfig;
-  @JsonProperty("segment_config")
-  private IntegrationModel segmentConfig;
-  @JsonProperty("mixpanel_config")
-  private IntegrationModel mixpanelConfig;
-  @JsonProperty("heap_config")
-  private IntegrationModel heapConfig;
+  @JsonProperty("identity_overrides")
+  private List<IdentityModel> identityOverrides;
 }

--- a/src/main/java/com/flagsmith/flagengine/identities/IdentityModel.java
+++ b/src/main/java/com/flagsmith/flagengine/identities/IdentityModel.java
@@ -29,7 +29,7 @@ public class IdentityModel extends BaseModel {
   @JsonProperty("identity_traits")
   private List<TraitModel> identityTraits = new ArrayList<>();
   @JsonProperty("identity_features")
-  private Set<FeatureStateModel> identityFeatures = new HashSet<>();
+  private List<FeatureStateModel> identityFeatures = new ArrayList<>();
   @JsonProperty("composite_key")
   private String compositeKey;
 

--- a/src/test/java/com/flagsmith/FlagsmithClientTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithClientTest.java
@@ -27,7 +27,6 @@ import com.flagsmith.flagengine.identities.traits.TraitModel;
 import com.flagsmith.interfaces.FlagsmithCache;
 import com.flagsmith.models.BaseFlag;
 import com.flagsmith.models.DefaultFlag;
-import com.flagsmith.models.Flag;
 import com.flagsmith.models.Flags;
 import com.flagsmith.models.Segment;
 import com.flagsmith.responses.FlagsAndTraitsResponse;
@@ -35,7 +34,6 @@ import com.flagsmith.threads.PollingManager;
 import com.flagsmith.threads.RequestProcessor;
 
 import java.io.IOException;
-import java.security.Identity;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -46,9 +44,7 @@ import okhttp3.Request;
 import okhttp3.ResponseBody;
 import okhttp3.mock.MockInterceptor;
 import okio.Buffer;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.invocation.Invocation;
@@ -600,7 +596,7 @@ public class FlagsmithClientTest {
 
         // Then
         // Identity overrides are correctly stored
-        IdentityModel actualIdentity = client.getIdentityOverridesByIdentifier().get("overridden-identity");
+        IdentityModel actualIdentity = client.getIdentitiesWithOverridesByIdentifier().get("overridden-identity");
 
         assertEquals(actualIdentity.getIdentityFeatures().size(), 1);
         assertEquals(actualIdentity.getIdentityFeatures().iterator().next().getValue(), "overridden-value");

--- a/src/test/java/com/flagsmith/FlagsmithTestHelper.java
+++ b/src/test/java/com/flagsmith/FlagsmithTestHelper.java
@@ -19,8 +19,10 @@ import io.restassured.RestAssured;
 import io.restassured.http.Header;
 import io.restassured.http.Headers;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
@@ -273,62 +275,110 @@ public class FlagsmithTestHelper {
     return user;
   }
 
+  public static IdentityModel identityOverride() {
+    final FeatureModel overriddenFeature = new FeatureModel();
+    overriddenFeature.setId(1);
+    overriddenFeature.setName("some_feature");
+    overriddenFeature.setType("STANDARD");
+
+    final FeatureStateModel overriddenFeatureState = new FeatureStateModel();
+    overriddenFeatureState.setFeature(overriddenFeature);
+    overriddenFeatureState.setFeaturestateUuid("d5d0767b-6287-4bb4-9d53-8b87e5458642");
+    overriddenFeatureState.setValue("overridden-value");
+    overriddenFeatureState.setEnabled(true);
+    overriddenFeatureState.setMultivariateFeatureStateValues(new ArrayList<>());
+
+    Set<FeatureStateModel> identityFeatures = new HashSet<>();
+    identityFeatures.add(overriddenFeatureState);
+
+    final IdentityModel identity = new IdentityModel();
+    identity.setIdentifier("overridden-identity");
+    identity.setIdentityUuid("65bc5ac6-5859-4cfe-97e6-d5ec2e80c1fb");
+    identity.setCompositeKey("B62qaMZNwfiqT76p38ggrQ_identity_overridden_identity");
+    identity.setEnvironmentApiKey("B62qaMZNwfiqT76p38ggrQ");
+    identity.setIdentityFeatures(identityFeatures);
+    return identity;
+  }
+
   public static EnvironmentModel environmentModel() {
     String environment = "{\n" +
-        "  \"api_key\": \"B62qaMZNwfiqT76p38ggrQ\",\n" +
-        "  \"project\": {\n" +
-        "    \"name\": \"Test project\",\n" +
-        "    \"organisation\": {\n" +
-        "      \"feature_analytics\": false,\n" +
-        "      \"name\": \"Test Org\",\n" +
-        "      \"id\": 1,\n" +
-        "      \"persist_trait_data\": true,\n" +
-        "      \"stop_serving_flags\": false\n" +
-        "    },\n" +
-        "    \"id\": 1,\n" +
-        "    \"hide_disabled_flags\": false,\n" +
-        "    \"segments\": [" +
-        "      {\n" +
-        "        \"id\": 1,\n" +
-        "        \"name\": \"Test segment\",\n" +
-        "        \"rules\": [\n" +
-        "          {\n" +
-        "            \"type\": \"ALL\",\n" +
-        "            \"rules\": [\n" +
-        "              {\n" +
-        "                \"type\": \"ALL\",\n" +
-        "                \"rules\": [],\n" +
-        "                \"conditions\": [\n" +
-        "                  {\n" +
-        "                    \"operator\": \"EQUAL\",\n" +
-        "                    \"property_\": \"foo\",\n" +
-        "                    \"value\": \"bar\"\n" +
-        "                  }\n" +
-        "                ]\n" +
-        "              }\n" +
-        "            ]\n" +
-        "          }\n" +
-        "        ]\n" +
-        "      }]\n" +
-        "  },\n" +
-        "  \"segment_overrides\": [],\n" +
-        "  \"id\": 1,\n" +
-        "  \"feature_states\": [\n" +
-        "    {\n" +
-        "      \"multivariate_feature_state_values\": [],\n" +
-        "      \"feature_state_value\": \"some-value\",\n" +
-        "      \"id\": 1,\n" +
-        "      \"featurestate_uuid\": \"40eb539d-3713-4720-bbd4-829dbef10d51\",\n" +
-        "      \"feature\": {\n" +
-        "        \"name\": \"some_feature\",\n" +
-        "        \"type\": \"STANDARD\",\n" +
-        "        \"id\": 1\n" +
-        "      },\n" +
-        "      \"segment_id\": null,\n" +
-        "      \"enabled\": true\n" +
-        "    }\n" +
-        "  ]\n" +
-        "}";
+    "  \"api_key\": \"B62qaMZNwfiqT76p38ggrQ\",\n" +
+    "  \"project\": {\n" +
+    "    \"name\": \"Test project\",\n" +
+    "    \"organisation\": {\n" +
+    "      \"feature_analytics\": false,\n" +
+    "      \"name\": \"Test Org\",\n" +
+    "      \"id\": 1,\n" +
+    "      \"persist_trait_data\": true,\n" +
+    "      \"stop_serving_flags\": false\n" +
+    "    },\n" +
+    "    \"id\": 1,\n" +
+    "    \"hide_disabled_flags\": false,\n" +
+    "    \"segments\": [\n" +
+    "      {\n" +
+    "        \"id\": 1,\n" +
+    "        \"name\": \"Test segment\",\n" +
+    "        \"rules\": [\n" +
+    "          {\n" +
+    "            \"type\": \"ALL\",\n" +
+    "            \"rules\": [\n" +
+    "              {\n" +
+    "                \"type\": \"ALL\",\n" +
+    "                \"rules\": [],\n" +
+    "                \"conditions\": [\n" +
+    "                  {\n" +
+    "                    \"operator\": \"EQUAL\",\n" +
+    "                    \"property_\": \"foo\",\n" +
+    "                    \"value\": \"bar\"\n" +
+    "                  }\n" +
+    "                ]\n" +
+    "              }\n" +
+    "            ]\n" +
+    "          }\n" +
+    "        ]\n" +
+    "      }\n" +
+    "    ]\n" +
+    "  },\n" +
+    "  \"segment_overrides\": [],\n" +
+    "  \"id\": 1,\n" +
+    "  \"feature_states\": [\n" +
+    "    {\n" +
+    "      \"multivariate_feature_state_values\": [],\n" +
+    "      \"feature_state_value\": \"some-value\",\n" +
+    "      \"id\": 1,\n" +
+    "      \"featurestate_uuid\": \"40eb539d-3713-4720-bbd4-829dbef10d51\",\n" +
+    "      \"feature\": {\n" +
+    "        \"name\": \"some_feature\",\n" +
+    "        \"type\": \"STANDARD\",\n" +
+    "        \"id\": 1\n" +
+    "      },\n" +
+    "      \"segment_id\": null,\n" +
+    "      \"enabled\": true\n" +
+    "    }\n" +
+    "  ],\n" +
+    "  \"identity_overrides\": [\n" +
+    "    {\n" +
+    "      \"identity_uuid\": \"65bc5ac6-5859-4cfe-97e6-d5ec2e80c1fb\",\n" +
+    "      \"identifier\": \"overridden-identity\",\n" +
+    "      \"composite_key\": \"B62qaMZNwfiqT76p38ggrQ_identity_overridden_identity\",\n" +
+    "      \"identity_features\": [\n" +
+    "        {\n" +
+    "          \"feature_state_value\": \"overridden-value\",\n" +
+    "          \"multivariate_feature_state_values\": [],\n" +
+    "          \"featurestate_uuid\": \"d5d0767b-6287-4bb4-9d53-8b87e5458642\",\n" +
+    "          \"feature\": {\n" +
+    "            \"name\": \"some_feature\",\n" +
+    "            \"type\": \"STANDARD\",\n" +
+    "            \"id\": 1\n" +
+    "          },\n" +
+    "          \"enabled\": true\n" +
+    "        }\n" +
+    "      ],\n" +
+    "      \"identity_traits\": [],\n" +
+    "      \"environment_api_key\": \"B62qaMZNwfiqT76p38ggrQ\"\n" +
+    "    }\n" +
+    "  ]\n" +
+    "}";
 
     try {
       return EnvironmentModel.load(MapperFactory.getMapper().readTree(environment), EnvironmentModel.class);

--- a/src/test/java/com/flagsmith/FlagsmithTestHelper.java
+++ b/src/test/java/com/flagsmith/FlagsmithTestHelper.java
@@ -288,7 +288,7 @@ public class FlagsmithTestHelper {
     overriddenFeatureState.setEnabled(true);
     overriddenFeatureState.setMultivariateFeatureStateValues(new ArrayList<>());
 
-    Set<FeatureStateModel> identityFeatures = new HashSet<>();
+    List<FeatureStateModel> identityFeatures = new ArrayList<>();
     identityFeatures.add(overriddenFeatureState);
 
     final IdentityModel identity = new IdentityModel();

--- a/src/test/java/com/flagsmith/FlagsmithTestHelper.java
+++ b/src/test/java/com/flagsmith/FlagsmithTestHelper.java
@@ -19,10 +19,8 @@ import io.restassured.RestAssured;
 import io.restassured.http.Header;
 import io.restassured.http.Headers;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
@@ -302,83 +300,84 @@ public class FlagsmithTestHelper {
 
   public static String environmentString() {
     return "{\n" +
-    "  \"api_key\": \"B62qaMZNwfiqT76p38ggrQ\",\n" +
-    "  \"project\": {\n" +
-    "    \"name\": \"Test project\",\n" +
-    "    \"organisation\": {\n" +
-    "      \"feature_analytics\": false,\n" +
-    "      \"name\": \"Test Org\",\n" +
-    "      \"id\": 1,\n" +
-    "      \"persist_trait_data\": true,\n" +
-    "      \"stop_serving_flags\": false\n" +
-    "    },\n" +
-    "    \"id\": 1,\n" +
-    "    \"hide_disabled_flags\": false,\n" +
-    "    \"segments\": [\n" +
-    "      {\n" +
-    "        \"id\": 1,\n" +
-    "        \"name\": \"Test segment\",\n" +
-    "        \"rules\": [\n" +
-    "          {\n" +
-    "            \"type\": \"ALL\",\n" +
-    "            \"rules\": [\n" +
-    "              {\n" +
-    "                \"type\": \"ALL\",\n" +
-    "                \"rules\": [],\n" +
-    "                \"conditions\": [\n" +
-    "                  {\n" +
-    "                    \"operator\": \"EQUAL\",\n" +
-    "                    \"property_\": \"foo\",\n" +
-    "                    \"value\": \"bar\"\n" +
-    "                  }\n" +
-    "                ]\n" +
-    "              }\n" +
-    "            ]\n" +
-    "          }\n" +
-    "        ]\n" +
-    "      }\n" +
-    "    ]\n" +
-    "  },\n" +
-    "  \"segment_overrides\": [],\n" +
-    "  \"id\": 1,\n" +
-    "  \"feature_states\": [\n" +
-    "    {\n" +
-    "      \"multivariate_feature_state_values\": [],\n" +
-    "      \"feature_state_value\": \"some-value\",\n" +
-    "      \"id\": 1,\n" +
-    "      \"featurestate_uuid\": \"40eb539d-3713-4720-bbd4-829dbef10d51\",\n" +
-    "      \"feature\": {\n" +
-    "        \"name\": \"some_feature\",\n" +
-    "        \"type\": \"STANDARD\",\n" +
-    "        \"id\": 1\n" +
-    "      },\n" +
-    "      \"segment_id\": null,\n" +
-    "      \"enabled\": true\n" +
-    "    }\n" +
-    "  ],\n" +
-    "  \"identity_overrides\": [\n" +
-    "    {\n" +
-    "      \"identity_uuid\": \"65bc5ac6-5859-4cfe-97e6-d5ec2e80c1fb\",\n" +
-    "      \"identifier\": \"overridden-identity\",\n" +
-    "      \"composite_key\": \"B62qaMZNwfiqT76p38ggrQ_identity_overridden_identity\",\n" +
-    "      \"identity_features\": [\n" +
-    "        {\n" +
-    "          \"feature_state_value\": \"overridden-value\",\n" +
-    "          \"multivariate_feature_state_values\": [],\n" +
-    "          \"featurestate_uuid\": \"d5d0767b-6287-4bb4-9d53-8b87e5458642\",\n" +
-    "          \"feature\": {\n" +
-    "            \"name\": \"some_feature\",\n" +
-    "            \"type\": \"STANDARD\",\n" +
-    "            \"id\": 1\n" +
-    "          },\n" +
-    "          \"enabled\": true\n" +
-    "        }\n" +
-    "      ],\n" +
-    "      \"identity_traits\": [],\n" +
-    "      \"environment_api_key\": \"B62qaMZNwfiqT76p38ggrQ\"\n" +
-    "    }\n" +
-    "  ]\n" +
-    "}";
+            "  \"api_key\": \"B62qaMZNwfiqT76p38ggrQ\",\n" +
+            "  \"project\": {\n" +
+            "    \"name\": \"Test project\",\n" +
+            "    \"organisation\": {\n" +
+            "      \"feature_analytics\": false,\n" +
+            "      \"name\": \"Test Org\",\n" +
+            "      \"id\": 1,\n" +
+            "      \"persist_trait_data\": true,\n" +
+            "      \"stop_serving_flags\": false\n" +
+            "    },\n" +
+            "    \"id\": 1,\n" +
+            "    \"hide_disabled_flags\": false,\n" +
+            "    \"segments\": [\n" +
+            "      {\n" +
+            "        \"id\": 1,\n" +
+            "        \"name\": \"Test segment\",\n" +
+            "        \"rules\": [\n" +
+            "          {\n" +
+            "            \"type\": \"ALL\",\n" +
+            "            \"rules\": [\n" +
+            "              {\n" +
+            "                \"type\": \"ALL\",\n" +
+            "                \"rules\": [],\n" +
+            "                \"conditions\": [\n" +
+            "                  {\n" +
+            "                    \"operator\": \"EQUAL\",\n" +
+            "                    \"property_\": \"foo\",\n" +
+            "                    \"value\": \"bar\"\n" +
+            "                  }\n" +
+            "                ]\n" +
+            "              }\n" +
+            "            ]\n" +
+            "          }\n" +
+            "        ]\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  \"segment_overrides\": [],\n" +
+            "  \"id\": 1,\n" +
+            "  \"feature_states\": [\n" +
+            "    {\n" +
+            "      \"multivariate_feature_state_values\": [],\n" +
+            "      \"feature_state_value\": \"some-value\",\n" +
+            "      \"id\": 1,\n" +
+            "      \"featurestate_uuid\": \"40eb539d-3713-4720-bbd4-829dbef10d51\",\n" +
+            "      \"feature\": {\n" +
+            "        \"name\": \"some_feature\",\n" +
+            "        \"type\": \"STANDARD\",\n" +
+            "        \"id\": 1\n" +
+            "      },\n" +
+            "      \"segment_id\": null,\n" +
+            "      \"enabled\": true\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"identity_overrides\": [\n" +
+            "    {\n" +
+            "      \"identity_uuid\": \"65bc5ac6-5859-4cfe-97e6-d5ec2e80c1fb\",\n" +
+            "      \"identifier\": \"overridden-identity\",\n" +
+            "      \"composite_key\": \"B62qaMZNwfiqT76p38ggrQ_identity_overridden_identity\",\n" +
+            "      \"identity_features\": [\n" +
+            "        {\n" +
+            "          \"feature_state_value\": \"overridden-value\",\n" +
+            "          \"multivariate_feature_state_values\": [],\n" +
+            "          \"featurestate_uuid\": \"d5d0767b-6287-4bb4-9d53-8b87e5458642\",\n" +
+            "          \"feature\": {\n" +
+            "            \"name\": \"some_feature\",\n" +
+            "            \"type\": \"STANDARD\",\n" +
+            "            \"id\": 1\n" +
+            "          },\n" +
+            "          \"enabled\": true\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"identity_traits\": [],\n" +
+            "      \"environment_api_key\": \"B62qaMZNwfiqT76p38ggrQ\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+  }
 
   public static EnvironmentModel environmentModel() {
     try {

--- a/src/test/java/com/flagsmith/flagengine/unit/environments/EnvironmentTest.java
+++ b/src/test/java/com/flagsmith/flagengine/unit/environments/EnvironmentTest.java
@@ -66,11 +66,6 @@ public class EnvironmentTest {
 
     Assertions.assertTrue(environmentModel.getFeatureStates().size() == 3);
 
-    Assertions.assertNull(environmentModel.getAmplitudeConfig());
-    Assertions.assertNull(environmentModel.getMixpanelConfig());
-    Assertions.assertNull(environmentModel.getHeapConfig());
-    Assertions.assertNull(environmentModel.getSegmentConfig());
-
     FeatureStateModel featureState = FeatureStateHelper.getFeatureStateForFeatureByName(
         environmentModel.getFeatureStates(),
         "feature_with_string_value"


### PR DESCRIPTION
Contributes to https://github.com/Flagsmith/flagsmith/issues/3132.

- Store environment-supplied identity overrides
- Use stored identity overrides in local evaluation mode
- Remove integration configurations from `EnvironmentModel`
- Change `IdentityModel.identity_features` type from `Set` to `List` to fix equality checks for identities. It seems that using a `HashSet` there initially was a mistake, as the `FeatureStateModel` class did not have `hashCode` implemented because `equals` was overridden (at least, I didn't observe the `hashCode` definition after delomboking in IDEA). Moreover, defining `FeatureStateModel.hashCode` is tricky as its collections need different deduplication in different contexts. 