### PR TITLE
fix: Retry logic was never applied.

### DIFF
--- a/src/main/java/com/flagsmith/threads/RequestProcessor.java
+++ b/src/main/java/com/flagsmith/threads/RequestProcessor.java
@@ -76,7 +76,6 @@ public class RequestProcessor {
   public <T> Future<T> executeAsync(
       Request request, TypeReference<T> clazz, Boolean doThrow, Retry retries) {
     CompletableFuture<T> completableFuture = new CompletableFuture<>();
-    Call call = getClient().newCall(request);
     Retry localRetry = retries.toBuilder().build();
     // run the execute method in a fixed thread with retries.
     executor.submit(() -> {
@@ -84,6 +83,7 @@ public class RequestProcessor {
       try {
         Integer statusCode = null;
         do {
+          Call call = getClient().newCall(request);
           localRetry.waitWithBackoff();
           Boolean throwOrNot = localRetry.getAttempts() == localRetry.getTotal()
               ? doThrow : Boolean.FALSE;

--- a/src/test/java/com/flagsmith/FlagsmithApiWrapperTest.java
+++ b/src/test/java/com/flagsmith/FlagsmithApiWrapperTest.java
@@ -66,6 +66,27 @@ public class FlagsmithApiWrapperTest {
   }
 
   @Test
+  void getFeatureFlags_retries() {
+    // Arrange
+    interceptor.addRule()
+        .get(BASE_URL + "/flags/")
+        .anyTimes()
+        .respond(503);
+
+    // Act
+    try {
+      sut.getFeatureFlags(true);
+    } catch (Exception e) {
+      // ignore
+    }
+
+    // Assert
+    // Since the Retry object is local to the call, the only external behaviour we can watch
+    // is the logger
+    verify(flagsmithLogger, times(2)).httpError(any(), any(Response.class), anyBoolean());
+  }
+
+  @Test
   public void getFeatureFlags_noUser_success() throws JsonProcessingException {
     // Arrange
     interceptor.addRule()


### PR DESCRIPTION
The implement of the Call object being stateful,
the retry logic was never triggered as an IllegalStateException was bypassing the normal flow.

Closes: #144