### PR TITLE
fix: thread safe analytics processor

### DIFF
--- a/src/test/java/com/flagsmith/threads/AnalyticsProcessorTest.java
+++ b/src/test/java/com/flagsmith/threads/AnalyticsProcessorTest.java
@@ -8,14 +8,23 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flagsmith.FlagsmithApiWrapper;
 import com.flagsmith.FlagsmithException;
 import com.flagsmith.FlagsmithLogger;
+import com.flagsmith.MapperFactory;
 import com.flagsmith.config.FlagsmithConfig;
 import com.flagsmith.config.Retry;
 import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
+
+import lombok.SneakyThrows;
 import okhttp3.Response;
 import okhttp3.mock.MockInterceptor;
+import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,5 +104,16 @@ public class AnalyticsProcessorTest {
 
     // Then
     verify(requestProcessor, times(1)).close();
+  }
+
+  @Test
+  @SneakyThrows
+  public void AnalyticsProcessor_longAdderGetsSerializedCorrectly() {
+    analytics.trackFeature("foo");
+
+    ObjectMapper mapper = MapperFactory.getMapper();
+    String response = mapper.writeValueAsString(analytics.getAnalyticsData());
+
+    Assertions.assertEquals("{\"foo\":1}", response);
   }
 }


### PR DESCRIPTION
I have noticed analytics processor threw some exceptions.

> JsonMappingException
(was java.util.ConcurrentModificationException) (through reference chain: java.util.HashMap["VELOCITY_SLOTS_ENABLED"])

Looking at code it is evident that those operations are not thread safe. They should be thread-safe considering flag access is also not thread safe.

Changes:
1. Update `analyticsData` to be `ConcurrentHashMap`.
2. Make sure `flush()` is only called once without concurrency.
3. Switch analytics data to use `LongAdder` which will have exact count rather than an approximation.
4. Clean the analytic map right after we unmarshall it so risk of losing data is minimal.