### PR TITLE
fix: java 8 incompatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ "11", "17", "21" ]
+        java: [ "8", "11", "17", "21" ]
         distribution: [ "zulu", "adopt" ]
 
     steps:

--- a/src/main/java/com/flagsmith/utils/ModelUtils.java
+++ b/src/main/java/com/flagsmith/utils/ModelUtils.java
@@ -3,6 +3,8 @@ package com.flagsmith.utils;
 import com.flagsmith.flagengine.identities.traits.TraitModel;
 import com.flagsmith.models.SdkTraitModel;
 import com.flagsmith.models.TraitConfig;
+
+import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -46,12 +48,8 @@ public class ModelUtils {
       Map<String, Object> traits
   ) {
     return traits.entrySet().stream().map(
-        (row) -> {
-          return Map.entry(
-            row.getKey(),
-            TraitConfig.fromObject(row.getValue())
-          );
-        }
+        row -> new AbstractMap.SimpleEntry<>(
+                row.getKey(), TraitConfig.fromObject(row.getValue()))
     );
   }
 

--- a/src/main/java/com/flagsmith/utils/ModelUtils.java
+++ b/src/main/java/com/flagsmith/utils/ModelUtils.java
@@ -3,7 +3,6 @@ package com.flagsmith.utils;
 import com.flagsmith.flagengine.identities.traits.TraitModel;
 import com.flagsmith.models.SdkTraitModel;
 import com.flagsmith.models.TraitConfig;
-
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Remove use of Map.entry() to maintain Java 8 compatibility (required by open feature, as is evident by failing CI [here](https://github.com/open-feature/java-sdk-contrib/pull/922))