### PR TITLE
ci: publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: adopt
-          java-version: 17
+          java-version: 21
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   publish-to-maven-central:
+    runs-on: ubuntu-latest
+    name: Publish to Maven Central
+
     steps:
       - id: install-secret-key
         name: Install gpg secret key

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ name: "Publish to Maven Central"
 on:
   push:
     tags: "*"
+    branches:
+      - "ci/publish-workflow"
 
 jobs:
   publish-to-maven-central:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,12 @@ jobs:
     name: Publish to Maven Central
 
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: adopt
+          java-version: 17
+
       - id: install-secret-key
         name: Install gpg secret key
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,4 +36,5 @@ jobs:
             --no-transfer-progress \
             --batch-mode \
             -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} \
+            -DskipTests \
             clean deploy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,4 +41,4 @@ jobs:
             --no-transfer-progress \
             --batch-mode \
             -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} \
-            clean deploy
+            clean deploy -P release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "*"
-    branches:
-      - "ci/publish-workflow"
 
 jobs:
   publish-to-maven-central:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: "Publish to Maven Central"
+
+on:
+  push:
+    tags: "*"
+
+jobs:
+  publish-to-maven-central:
+    steps:
+      - id: install-secret-key
+        name: Install gpg secret key
+        run: |
+          # Install gpg secret key
+          cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
+          # Verify gpg secret key
+          gpg --list-secret-keys --keyid-format LONG
+      - id: publish-to-central
+        name: Publish to Central Repository
+        env:
+          MAVEN_USERNAME: ${{ vars.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+        run: |
+          mvn \
+            --no-transfer-progress \
+            --batch-mode \
+            -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} \
+            clean deploy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           distribution: adopt
           java-version: 17
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
 
       - id: install-secret-key
         name: Install gpg secret key

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,6 @@
+# References:
+#  - https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-java-packages-with-maven
+
 name: "Publish to Maven Central"
 
 on:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: actions/setup-java@v4
         with:
           distribution: adopt
@@ -36,5 +38,4 @@ jobs:
             --no-transfer-progress \
             --batch-mode \
             -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} \
-            -DskipTests \
             clean deploy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,8 @@ name: "Publish to Maven Central"
 
 on:
   push:
-    tags: "*"
+    tags:
+      - "*"
     branches:
       - "ci/publish-workflow"
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.flagsmith</groupId>
   <artifactId>flagsmith-java-client</artifactId>
-  <version>7.4.2.alpha1</version>
+  <version>7.4.3.alpha1</version>
   <packaging>jar</packaging>
 
   <name>Flagsmith Java Client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.flagsmith</groupId>
+  <groupId>com.flagsmith</groupId>
   <artifactId>flagsmith-java-client</artifactId>
-  <version>7.4.3.alpha1</version>
+  <version>7.4.2</version>
   <packaging>jar</packaging>
 
   <name>Flagsmith Java Client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.flagsmith</groupId>
+  <groupId>io.flagsmith</groupId>
   <artifactId>flagsmith-java-client</artifactId>
-  <version>7.4.2</version>
+  <version>7.4.2.alpha1</version>
   <packaging>jar</packaging>
 
   <name>Flagsmith Java Client</name>
@@ -181,6 +181,16 @@
   <build>
     <finalName>flagsmith-java-client-${project.version}</finalName>
     <plugins>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.6.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Adds the necessary changes to automatically publish the Java client to Maven Central when a new tag is created. 

You can see a successful run (albeit to io.flagsmith, not com.flagsmith) [here](https://github.com/Flagsmith/flagsmith-java-client/actions/runs/12238852074/job/34137899403).  

~TODO still: migrate the java client from legacy sonatype to central, but this theoretically should be a click of a button in sonatype 🤞 .~
