### PR TITLE
docs: removing hero image and broken build badge from SDK readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-<img width="100%" src="https://github.com/Flagsmith/flagsmith/raw/main/static-files/hero.png"/>
-
 [![Download](https://img.shields.io/maven-central/v/com.flagsmith/flagsmith-java-client)](https://mvnrepository.com/artifact/com.flagsmith/flagsmith-java-client)
-![build](https://github.com/Flagsmith/flagsmith-java-client/actions/workflows/maven.yml/badge.svg)
 
 # Flagsmith Java SDK
 


### PR DESCRIPTION
To remove the risk of these breaking when we make changes in flagsmith/flagsmith we're removing these image references from the readme.md files of the SDK repos. Additionally fixing the broken button.