### PR TITLE
feat: Expose ConnectionPool customization on FlagsmithConfig.Builder

### DIFF
--- a/src/main/java/com/flagsmith/config/FlagsmithConfig.java
+++ b/src/main/java/com/flagsmith/config/FlagsmithConfig.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
 import lombok.Getter;
+import okhttp3.ConnectionPool;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
@@ -64,6 +65,9 @@ public final class FlagsmithConfig {
     if (builder.proxy != null) {
       httpBuilder.proxy(builder.proxy);
     }
+    if (builder.connectionPool != null) {
+      httpBuilder.connectionPool(builder.connectionPool);
+    }
     if (!builder.supportedProtocols.isEmpty()) {
       httpBuilder.protocols(
           builder.supportedProtocols.stream()
@@ -110,6 +114,7 @@ public final class FlagsmithConfig {
     private X509TrustManager trustManager;
     private FlagsmithFlagDefaults flagsmithFlagDefaults;
     private AnalyticsProcessor analyticsProcessor;
+    private ConnectionPool connectionPool;
 
     private Boolean enableLocalEvaluation = Boolean.FALSE;
     private Integer environmentRefreshIntervalSeconds = DEFAULT_ENVIRONMENT_REFRESH_SECONDS;
@@ -200,6 +205,18 @@ public final class FlagsmithConfig {
      */
     public Builder withProxy(Proxy proxy) {
       this.proxy = proxy;
+      return this;
+    }
+
+    /**
+     * Provide a custom OkHttp ConnectionPool to tune keep-alive duration and maximum idle
+     * connections. When not set, OkHttp's defaults are used.
+     *
+     * @param connectionPool the ConnectionPool to use for the HTTP client
+     * @return the Builder
+     */
+    public Builder connectionPool(ConnectionPool connectionPool) {
+      this.connectionPool = connectionPool;
       return this;
     }
 

--- a/src/test/java/com/flagsmith/config/FlagsmithConfigTest.java
+++ b/src/test/java/com/flagsmith/config/FlagsmithConfigTest.java
@@ -2,12 +2,15 @@ package com.flagsmith.config;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.flagsmith.config.FlagsmithConfig.Protocol;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import okhttp3.ConnectionPool;
 import okhttp3.mock.MockInterceptor;
 import org.junit.jupiter.api.Test;
 
@@ -54,6 +57,29 @@ public class FlagsmithConfigTest {
   }
 
   @Test
+  public void configTest_customConnectionPool_respectsKeepAliveAndMaxIdle() throws Exception {
+    final ConnectionPool pool = new ConnectionPool(7, 42, TimeUnit.SECONDS);
+
+    final FlagsmithConfig flagsmithConfig = FlagsmithConfig.newBuilder()
+        .connectionPool(pool)
+        .build();
+
+    final ConnectionPool wired = flagsmithConfig.getHttpClient().connectionPool();
+    final Object delegate = readField(wired, "delegate");
+    assertEquals(7, readInt(delegate, "maxIdleConnections"));
+    assertEquals(TimeUnit.SECONDS.toNanos(42), readLong(delegate, "keepAliveDurationNs"));
+  }
+
+  @Test
+  public void configTest_nullConnectionPool_isSafeAndUsesDefault() {
+    final FlagsmithConfig flagsmithConfig = FlagsmithConfig.newBuilder()
+        .connectionPool(null)
+        .build();
+
+    assertNotNull(flagsmithConfig.getHttpClient().connectionPool());
+  }
+
+  @Test
   public void configTest_supportedProtocols() {
     final FlagsmithConfig defaultFlagsmithConfig = FlagsmithConfig.newBuilder().build();
 
@@ -64,5 +90,19 @@ public class FlagsmithConfigTest {
 
     assertEquals(1, customFlagsmithConfig.getHttpClient().protocols().size());
     assertEquals(okhttp3.Protocol.HTTP_1_1, customFlagsmithConfig.getHttpClient().protocols().get(0));
+  }
+
+  private static Object readField(Object target, String fieldName) throws Exception {
+    java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.get(target);
+  }
+
+  private static int readInt(Object target, String fieldName) throws Exception {
+    return (int) readField(target, fieldName);
+  }
+
+  private static long readLong(Object target, String fieldName) throws Exception {
+    return (long) readField(target, fieldName);
   }
 }


### PR DESCRIPTION
## Summary

Adds `connectionPool(ConnectionPool)` to `FlagsmithConfig.Builder` so users can tune OkHttp's idle connection behavior (keepAlive duration and max idle connections). This is the API requested in #207 for users running behind intermediaries (AWS ALB, nginx) that close idle sockets sooner than OkHttp's default of 5 minutes.

Default behavior is unchanged: when `connectionPool()` is not called (or is called with `null`), OkHttp's default pool is used, so existing users see no difference.

## Usage

```java
FlagsmithConfig config = FlagsmithConfig.newBuilder()
    .connectionPool(new ConnectionPool(5, 30, TimeUnit.SECONDS))
    .build();
```

## Tests

Two new tests in `FlagsmithConfigTest`:

1. `configTest_customConnectionPool_respectsKeepAliveAndMaxIdle` reflects into `ConnectionPool.delegate` and asserts the user's `maxIdleConnections` and `keepAliveDurationNs` reach the live pool. Mutation tested: removing the constructor wiring fails this test.
2. `configTest_nullConnectionPool_isSafeAndUsesDefault` passes `null` explicitly and asserts no NPE; a default OkHttp pool is still wired. Mutation tested: removing the null guard fails this test.

Both tests pass on OkHttp 5.x and OkHttp 4.x (via the `test-okhttp4` profile).

