### PR TITLE
fix: respect rule type for sub-rules in segment evaluation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/test/java/com/flagsmith/flagengine/enginetestdata"]
 	path = src/test/java/com/flagsmith/flagengine/enginetestdata
 	url = git@github.com:Flagsmith/engine-test-data.git
-	branch = v3.5.0
+	branch = v3.7.0

--- a/src/main/java/com/flagsmith/flagengine/segments/SegmentEvaluator.java
+++ b/src/main/java/com/flagsmith/flagengine/segments/SegmentEvaluator.java
@@ -71,8 +71,27 @@ public class SegmentEvaluator {
       }
     }
 
-    return isMatch && rule.getRules().stream()
-        .allMatch((subRule) -> contextMatchesRule(context, subRule, segmentKey));
+    if (!isMatch) {
+      return false;
+    }
+
+    List<SegmentRule> subRules = rule.getRules();
+    if (subRules.isEmpty()) {
+      return true;
+    }
+
+    Predicate<SegmentRule> subRulePredicate = (subRule) -> contextMatchesRule(
+        context, subRule, segmentKey);
+    switch (rule.getType()) {
+      case ALL:
+        return subRules.stream().allMatch(subRulePredicate);
+      case ANY:
+        return subRules.stream().anyMatch(subRulePredicate);
+      case NONE:
+        return subRules.stream().noneMatch(subRulePredicate);
+      default:
+        return false;
+    }
   }
 
   private static Boolean contextMatchesCondition(

--- a/src/test/java/com/flagsmith/flagengine/unit/segments/SegmentEvaluatorTest.java
+++ b/src/test/java/com/flagsmith/flagengine/unit/segments/SegmentEvaluatorTest.java
@@ -38,7 +38,7 @@ public class SegmentEvaluatorTest {
         Arguments.of(segmentMultipleConditionsAny(), oneIdentityTrait(), Boolean.TRUE),
         Arguments.of(segmentMultipleConditionsAny(), twoIdentityTraits(), Boolean.TRUE),
         Arguments.of(segmentNestedRules(), emptyIdentityTraits(), Boolean.FALSE),
-        Arguments.of(segmentNestedRules(), oneIdentityTrait(), Boolean.FALSE),
+        Arguments.of(segmentNestedRules(), oneIdentityTrait(), Boolean.TRUE),
         Arguments.of(segmentNestedRules(), threeIdentityTraits(), Boolean.TRUE),
         Arguments.of(segmentConditionsAndNestedRules(), emptyIdentityTraits(), Boolean.FALSE),
         Arguments.of(segmentConditionsAndNestedRules(), oneIdentityTrait(), Boolean.FALSE),


### PR DESCRIPTION
## Summary
- Bumped engine-test-data submodule from v3.5.0 to v3.7.0
- Fixed segment evaluation: sub-rules now respect the parent rule's type (ANY/ALL/NONE) instead of hardcoding ALL
- Updated unit test expectation to match corrected behavior

Equivalent fix to [flagsmith-engine#313](https://github.com/Flagsmith/flagsmith-engine/pull/313).

## Test plan
- [x] Bumped engine-test-data to v3.7.0 (includes new sub-rule type test cases)
- [x] Verified tests fail before the fix (2 failures from engine-test-data, then 1 from unit test)
- [x] Applied the fix to SegmentEvaluator.java
- [x] Updated SegmentEvaluatorTest.java to match corrected behavior
- [x] Verified all 403 tests pass after the fix