### PR TITLE
fix: handles integer foreign-key priority

### DIFF
--- a/src/main/java/com/flagsmith/models/features/FeatureSegmentModel.java
+++ b/src/main/java/com/flagsmith/models/features/FeatureSegmentModel.java
@@ -6,4 +6,13 @@ import lombok.Data;
 @Data
 public class FeatureSegmentModel extends BaseModel {
   private Integer priority;
+
+  public FeatureSegmentModel() {
+  }
+
+  // Tolerates the integer foreign-key shape emitted by self-hosted Core/EE
+  // /api/v1/identities/ — Edge emits {"priority": <int>} instead.
+  public FeatureSegmentModel(Integer priority) {
+    this.priority = priority;
+  }
 }

--- a/src/test/java/com/flagsmith/flagengine/models/FeatureSegmentModelTest.java
+++ b/src/test/java/com/flagsmith/flagengine/models/FeatureSegmentModelTest.java
@@ -1,0 +1,58 @@
+package com.flagsmith.flagengine.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.flagsmith.MapperFactory;
+import com.flagsmith.models.features.FeatureStateModel;
+import org.junit.jupiter.api.Test;
+
+public class FeatureSegmentModelTest {
+
+  @Test
+  public void deserializesFeatureSegmentAsIntegerForeignKey() throws JsonProcessingException {
+    String json = "{"
+        + "\"feature\": {\"id\": 1, \"name\": \"my_feature\", \"type\": \"STANDARD\"},"
+        + "\"enabled\": true,"
+        + "\"feature_state_value\": \"foo\","
+        + "\"feature_segment\": 321"
+        + "}";
+
+    FeatureStateModel model =
+        MapperFactory.getMapper().readValue(json, FeatureStateModel.class);
+
+    assertThat(model.getFeatureSegment()).isNotNull();
+    assertThat(model.getFeatureSegment().getPriority()).isEqualTo(321);
+  }
+
+  @Test
+  public void deserializesFeatureSegmentAsEngineObject() throws JsonProcessingException {
+    String json = "{"
+        + "\"feature\": {\"id\": 1, \"name\": \"my_feature\", \"type\": \"STANDARD\"},"
+        + "\"enabled\": true,"
+        + "\"feature_state_value\": \"foo\","
+        + "\"feature_segment\": {\"priority\": 5}"
+        + "}";
+
+    FeatureStateModel model =
+        MapperFactory.getMapper().readValue(json, FeatureStateModel.class);
+
+    assertThat(model.getFeatureSegment()).isNotNull();
+    assertThat(model.getFeatureSegment().getPriority()).isEqualTo(5);
+  }
+
+  @Test
+  public void deserializesNullFeatureSegment() throws JsonProcessingException {
+    String json = "{"
+        + "\"feature\": {\"id\": 1, \"name\": \"my_feature\", \"type\": \"STANDARD\"},"
+        + "\"enabled\": true,"
+        + "\"feature_state_value\": \"foo\","
+        + "\"feature_segment\": null"
+        + "}";
+
+    FeatureStateModel model =
+        MapperFactory.getMapper().readValue(json, FeatureStateModel.class);
+
+    assertThat(model.getFeatureSegment()).isNull();
+  }
+}


### PR DESCRIPTION
Closes #214 , restoring previous [behavior](https://github.com/Flagsmith/flagsmith-java-client/blob/v7.4.3/src/main/java/com/flagsmith/flagengine/features/FeatureSegmentModel.java)

- Fixes `MismatchedInputException` thrown by SDK 8.0.0–8.1.0 when deserializing `/api/v1/identities/` responses from self-hosted Core/EE that include a flag with a segment override.
- Root cause: PR #184 dropped the `FeatureSegmentModel(Integer)` constructor that Jackson was using as a delegating creator to coerce Core/EE's integer FK shape (`feature_segment: 321`) into the model. Edge emits `feature_segment: {"priority": <int>}` and is unaffected.
- Restores the `Integer`-arg constructor (mirrors pre-#184 shape) so both wire formats deserialize correctly.
- SaaS / `edge.api.flagsmith.com` users were never affected.
- Core/EE wire-format inconsistency is the deeper issue and will be tracked separately — the SDK still needs this tolerance long-term to support older self-hosted installs.

  ## Test plan
- [x] Added `FeatureSegmentModelTest` covering the three shapes: integer FK (Core/EE), engine object (Edge), and null (no segment override). Verified the integer-FK test fails on `main` with the reported exception, then passes after the fix.
  - [x] Full unit test suite passes locally with no regressions.